### PR TITLE
Use the grid helper to declare width

### DIFF
--- a/demos/footer.html
+++ b/demos/footer.html
@@ -1,18 +1,16 @@
 <!DOCTYPE html>
-<!--[if IE 7]>         <html class="o-useragent-ie7 o-hoverable-on"> <![endif]-->
-<!--[if IE 8]>         <html class="o-useragent-ie8 o-hoverable-on"> <![endif]-->
-<!--[if gt IE 8]><!--> <html class="o-hoverable-on"> <!--<![endif]-->
+<html class="o-hoverable-on ">
 <head>
 	<meta charset="utf-8" />
 	<meta http-equiv="X-UA-Compatible" content="IE=Edge" />
 	<title>o-footer: footer demo</title>
 	<meta name="viewport" content="initial-scale=1.0, width=device-width" />
-	<script src="//polyfill.webservices.ft.com/v1/polyfill.min.js?features=modernizr:html5,modernizr:svg,modernizr:datauri,default"></script>
+	<script src="//polyfill.webservices.ft.com/v1/polyfill.min.js?features=html5,svg,datauri,default"></script>
 	<style>body { margin: 0; } .demo-js .o--if-nojs { display: none; }</style>
 	<script>(function(d) { d.className = d.className + ' demo-js'; })(document.documentElement);</script>
 	<link rel="stylesheet" href="/bundles/css?modules=o-footer:/demos/src/demo.scss,o-fonts@^1.4.0" />
 </head>
-<body class="">
+<body>
 <footer class="o-footer" data-o-component="o-footer">
 	<nav class="o-footer__row">
 		<div class="o-footer__col o-footer__col--full-width">

--- a/main.scss
+++ b/main.scss
@@ -92,7 +92,7 @@ $o-footer-spacing-unit: 20px;
 	@include oGridColumn((default: 12, S: 6, M: 4, L: 3, XL: 2));
 }
 .o-footer__col--full-width {
-	width: oGridColspan(full-width);
+	@include oGridColumn(full-width);
 }
 
 .o-footer__copyright {


### PR DESCRIPTION
It's better to rely on the grid helper from now on, since there might be changes made to o-grid that would make `width: oGridColspan()` work badly.