### PR TITLE
Ease the transition to Nikkei

### DIFF
--- a/demos/footer-theme-light.html
+++ b/demos/footer-theme-light.html
@@ -75,11 +75,11 @@
 			<span><abbr title="Financial Times">FT</abbr> and ‘Financial Times’ are trademarks of The Financial Times Ltd.</span>
 		</div>
 	</div>
-	<div class="o-footer__pearson">
+	<div class="o-footer__parentcompany">
 		<div class="o-footer__row">
 			<div class="o-footer__col o-footer__col--full-width">
-				<div class="o-footer__pearson-tagline" aria-label="Always Learning"></div>
-				<div class="o-footer__pearson-logo" aria-label="Pearson"></div>
+				<div class="o-footer__parentcompany-tagline"></div>
+				<div class="o-footer__parentcompany-logo"></div>
 			</div>
 		</div>
 	</div>

--- a/demos/footer.html
+++ b/demos/footer.html
@@ -75,11 +75,11 @@
 			<span><abbr title="Financial Times">FT</abbr> and ‘Financial Times’ are trademarks of The Financial Times Ltd.</span>
 		</div>
 	</div>
-	<div class="o-footer__pearson">
+	<div class="o-footer__parentcompany">
 		<div class="o-footer__row">
 			<div class="o-footer__col o-footer__col--full-width">
-				<div class="o-footer__pearson-tagline" aria-label="Always Learning"></div>
-				<div class="o-footer__pearson-logo" aria-label="Pearson"></div>
+				<div class="o-footer__parentcompany-tagline"></div>
+				<div class="o-footer__parentcompany-logo"></div>
 			</div>
 		</div>
 	</div>

--- a/main.mustache
+++ b/main.mustache
@@ -27,11 +27,11 @@
 			<span><abbr title="Financial Times">FT</abbr> and ‘Financial Times’ are trademarks of The Financial Times Ltd.</span>
 		</div>
 	</div>
-	<div class="o-footer__pearson">
+	<div class="o-footer__parentcompany">
 		<div class="o-footer__row">
 			<div class="o-footer__col o-footer__col--full-width">
-				<div class="o-footer__pearson-tagline" aria-label="Always Learning"></div>
-				<div class="o-footer__pearson-logo" aria-label="Pearson"></div>
+				<div class="o-footer__parentcompany-tagline"></div>
+				<div class="o-footer__parentcompany-logo"></div>
 			</div>
 		</div>
 	</div>

--- a/main.scss
+++ b/main.scss
@@ -9,14 +9,16 @@ $o-footer-spacing-unit: 20px;
 
 @include oColorsSetUseCase(o-footer, background, 'grey-tint5');
 @include oColorsSetUseCase(o-footer, text, 'white');
-@include oColorsSetUseCase(o-footer__pearson, background, 'grey-tint4');
+@include oColorsSetUseCase(o-footer__pearson, background, 'grey-tint4'); // Deprecated
+@include oColorsSetUseCase(o-footer__parentcompany, background, 'grey-tint4');
 @include oColorsSetUseCase(o-footer__divider, border, 'white');
 @include oColorsSetUseCase(o-footer-item, text, 'white');
 @include oColorsSetUseCase(o-footer__copyright, text, 'grey-tint2');
 
 @include oColorsSetUseCase(o-footer--theme-light, background, 'pink-tint1');
 @include oColorsSetUseCase(o-footer--theme-light, text, 'grey-tint5');
-@include oColorsSetUseCase(o-footer--theme-light__pearson, background, 'pink-tint4');
+@include oColorsSetUseCase(o-footer--theme-light__pearson, background, 'pink-tint4'); // Deprecated
+@include oColorsSetUseCase(o-footer--theme-light__parentcompany, background, 'pink-tint4');
 @include oColorsSetUseCase(o-footer--theme-light__divider, border, 'pink-tint3');
 @include oColorsSetUseCase(o-footer--theme-light-item, text, 'grey-tint5');
 @include oColorsSetUseCase(o-footer--theme-light__copyright, text, 'grey-tint3');
@@ -143,13 +145,13 @@ $o-footer-spacing-unit: 20px;
 
 .o-footer__pearson, // deprecated
 .o-footer__parentcompany {
-	background-color: oColorsGetColorFor(o-footer__pearson o-footer, background);
+	background-color: oColorsGetColorFor(o-footer__pearson o-footer__parentcompany o-footer, background);
 	padding-top: $o-footer-spacing-unit - 5;
 	padding-bottom: $o-footer-spacing-unit - 5;
 	color: oColorsGetColorFor(o-footer__pearson o-footer, text);
 
 	.o-footer--theme-light & {
-		background-color: oColorsGetColorFor(o-footer--theme-light__pearson o-footer, background);
+		background-color: oColorsGetColorFor(o-footer--theme-light__pearson o-footer--theme-light__parentcompany o-footer, background);
 		color: oColorsGetColorFor(o-footer--theme-light__pearson o-footer, text);
 	}
 }

--- a/main.scss
+++ b/main.scss
@@ -141,7 +141,8 @@ $o-footer-spacing-unit: 20px;
 	}
 }
 
-.o-footer__pearson {
+.o-footer__pearson, // deprecated
+.o-footer__parentcompany {
 	background-color: oColorsGetColorFor(o-footer__pearson o-footer, background);
 	padding-top: $o-footer-spacing-unit - 5;
 	padding-bottom: $o-footer-spacing-unit - 5;
@@ -153,8 +154,10 @@ $o-footer-spacing-unit: 20px;
 	}
 }
 
-.o-footer__pearson-tagline,
-.o-footer__pearson-logo {
+.o-footer__pearson-tagline, // deprecated
+.o-footer__pearson-logo, // deprecated
+.o-footer__parentcompany-tagline,
+.o-footer__parentcompany-logo {
 	height: 16px;
 	background-image: url(oAssetsResolve("img/pearson_sprite.gif", o-footer));
 	background-repeat: no-repeat;
@@ -164,12 +167,14 @@ $o-footer-spacing-unit: 20px;
 	background: rgba(0, 0, 0, 0.001) url(oAssetsResolve("img/pearson_sprite.svg", o-footer)) no-repeat;
 }
 
-.o-footer__pearson-tagline {
+.o-footer__pearson-tagline, // deprecated
+.o-footer__parentcompany-tagline {
 	float: left;
 	width: 170px;
 }
 
-.o-footer__pearson-logo {
+.o-footer__pearson-logo, // deprecated
+.o-footer__parentcompany-logo {
 	float: right;
 	width: 100px;
 	background-position: right 0;
@@ -200,7 +205,8 @@ $o-footer-spacing-unit: 20px;
 	}
 
 	// Inside media query to hide from browsers that don't support MQs and therefore also don't support max-width or background-size
-	.o-footer__pearson-tagline {
+	.o-footer__pearson-tagline, // deprecated
+	.o-footer__parentcompany-tagline {
 		max-width: 170px;
 		// need to keep 17/28 of the width visible
 		// but we round down to 27 to allow for browser pixel rounding errors
@@ -209,7 +215,8 @@ $o-footer-spacing-unit: 20px;
 		// but we round down to 16 to allow for browser pixel rounding errors
 		width: (1600% / 27);
 	}
-	.o-footer__pearson-logo {
+	.o-footer__pearson-logo, // deprecated
+	.o-footer__parentcompany-logo {
 		max-width: 100px;
 		// need to keep 10/28 of the width visible
 		// but we round down to 27 to allow for browser pixel rounding errors


### PR DESCRIPTION
This PR removes markup ties to Pearson, to make sure future versions of the footer are easy to update from our side at once.