### PR TITLE
Enlarge link tap targets

### DIFF
--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -2,5 +2,5 @@
 
 body {
 	@include oColorsFor(page);
-	font-family: BentonSans, sans-serif;
+	font-family: MetricWeb, sans-serif;
 }

--- a/main.scss
+++ b/main.scss
@@ -23,7 +23,7 @@ $o-footer-spacing-unit: 20px;
 
 .o-footer {
 	@include oColorsFor(o-footer, text background);
-	font-size: 14px;
+	font-size: 16px;
 	margin-top: (2 * $o-footer-spacing-unit);
 	padding: 0;
 	border-top: 5px solid oColorsGetColorFor(o-footer-brand product-brand, background);
@@ -72,7 +72,7 @@ $o-footer-spacing-unit: 20px;
 	> a {
 		display: block; // Make links easier to tap by increasing their hitzone
 		text-decoration: none;
-		padding: 2px 0;
+		padding: 5px 0;
 		color: oColorsGetColorFor(o-footer-item, text);
 
 		.o-footer--theme-light & {


### PR DESCRIPTION
Fixes #46

Google's guidance is 32px: https://developers.google.com/speed/docs/insights/SizeTapTargetsAppropriately

This is as near as I could get to Google's guidance without a real design change.