### PR TITLE
Remove: editionSwitcher flag logic

### DIFF
--- a/templates/footer.html
+++ b/templates/footer.html
@@ -10,13 +10,13 @@
 					{{/unless}}
 				{{/each}}
 
-				{{#ifAll flags.editionSwitcher editions}}
+				{{#if editions}}
 					{{#each editions.others}}
 						<li class="o-footer__item o-footer__item--top-level">
 							<a href="/{{id}}?edition={{id}}" class="o-footer__link" data-trackable="{{id}}-edition">{{name}} Edition</a>
 						</li>
 					{{/each}}
-				{{/ifAll}}
+				{{/if}}
 			</ol>
 			{{#each nav}}
 				{{#if children}}


### PR DESCRIPTION
cc @ironsidevsquincy 

Seems a good idea to remove this logic and delete the flag now (rather than having to keep extending its deadline) while we wait on final release.

Logic removed from `o-header`: https://github.com/Financial-Times/o-header/pull/153