### PR TITLE
Don't use Bold font

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -51,8 +51,8 @@ $o-footer-spacing-unit: 20px;
 	text-transform: uppercase;
 	white-space: nowrap;
 	text-overflow: ellipsis;
-	font-weight: bold;
-	font-size: 1em;
+	font-weight: 600;
+	font-size: 1.1em;
 	color: oColorsGetColorFor(o-footer-item, text);
 
 	// Make the white text look crisper and less bold on dark backgrounds


### PR DESCRIPTION
`font-weight: bold` gets transformed into `font-weight: 700` when built. `700` isn't a weight we normally use and this means the `MetricWeb-Bold` font gets downloaded just to render these headings. Using `600` is the usual MetricWeb bold weight.

The font size has been increased to put the pop back into the text.

**Before:**

<img width="1355" alt="__--_todo__enter_a_title_here_--_" src="https://cloud.githubusercontent.com/assets/684559/15508413/3c0249a2-21c7-11e6-9c33-166105476eb1.png">

**After:**
<img width="1340" alt="__--_todo__enter_a_title_here_--_" src="https://cloud.githubusercontent.com/assets/684559/15508405/3188ac8c-21c7-11e6-802e-508b26f4a5a8.png">

