### PR TITLE
widen o-icons semver range

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,6 +12,6 @@
     "o-toggle": "^1.0.0",
     "o-typography": "^4.1.0",
     "o-viewport": "^2.2.0",
-    "o-icons": "^4.4.2"
+    "o-icons": ">=4.4.2 <6"
   }
 }


### PR DESCRIPTION
So that projects can choose to migrate o-icons to v5 or leave it,
this commit widens the accepted semver range for o-icons to anything
above 4.4.2 but less than the next major (which would be 6)