### PR TITLE
Improve focus styles

### DIFF
--- a/origami.json
+++ b/origami.json
@@ -20,7 +20,7 @@
 	"demosDefaults": {
 		"js": "demos/src/demo.js",
 		"sass": "demos/src/demo.scss",
-		"dependencies": "o-fonts"
+		"dependencies": "o-fonts,o-normalise"
 	},
 	"demos": [
 		{

--- a/src/js/footer.js
+++ b/src/js/footer.js
@@ -39,6 +39,7 @@ class Footer {
 		Array.prototype.forEach.call(toggleEls, toggleEl => {
 			const target = document.getElementById(toggleEl.getAttribute('aria-controls'));
 			toggleEl.setAttribute('role', 'button');
+			toggleEl.setAttribute('tabindex', '0');
 			this._toggles.push(new Toggle(toggleEl, { target }));
 		});
 	}

--- a/src/scss/_footer.scss
+++ b/src/scss/_footer.scss
@@ -49,6 +49,8 @@
 
 	.o-footer__external-link {
 		position: relative;
+		border-top: 1px solid;
+		border-bottom: 1px solid;
 
 		// Hack to increase sepcificity to override overflow
 		// set on class used on the same element preventing use of !important.
@@ -66,7 +68,6 @@
 			width: 100vw;
 			left: 50%;
 			margin-left: -50vw;
-			border-top: 1px solid;
 		}
 
 		&:before {

--- a/src/scss/_matrix.scss
+++ b/src/scss/_matrix.scss
@@ -77,7 +77,11 @@
 	}
 
 	.o-footer__matrix-link {
-		@include oTypographyPadding($bottom: 4);
+		@include oTypographyPadding($bottom: 2, $top:2);
 		display: block;
+
+		&:first-child {
+			margin-top: -(oTypographySpacingSize($units: 2));
+		}
 	}
 }

--- a/src/scss/_matrix.scss
+++ b/src/scss/_matrix.scss
@@ -37,7 +37,7 @@
 			$line-size: $o-footer-spacing-unit * 2;
 
 			position: relative;
-			border-top: 1px dotted;
+			border-top: 1px solid;
 			line-height: $line-size;
 			cursor: pointer;
 

--- a/src/scss/_matrix.scss
+++ b/src/scss/_matrix.scss
@@ -77,7 +77,7 @@
 	}
 
 	.o-footer__matrix-link {
-		@include oTypographyPadding($bottom: 2, $top:2);
+		@include oTypographyPadding($bottom: 2, $top: 2);
 		display: block;
 
 		&:first-child {

--- a/src/scss/_themes.scss
+++ b/src/scss/_themes.scss
@@ -10,7 +10,7 @@
 		// sass-lint:enable no-vendor-prefixes
 
 		.o-footer__external-link,
-		.o-footer__matrix-title[aria-expanded]{
+		.o-footer__matrix-title[aria-expanded] {
 			border-color: oColorsGetColorFor('o-footer-dark', 'border');
 		}
 

--- a/src/scss/_themes.scss
+++ b/src/scss/_themes.scss
@@ -9,8 +9,8 @@
 		-moz-osx-font-smoothing: grayscale;
 		// sass-lint:enable no-vendor-prefixes
 
-		.o-footer__matrix-title:before,
-		.o-footer__matrix-title:after {
+		.o-footer__external-link,
+		.o-footer__matrix-title[aria-expanded]{
 			border-color: oColorsGetColorFor('o-footer-dark', 'border');
 		}
 
@@ -51,8 +51,8 @@
 			color: oColorsGetColorFor('o-footer-light-title', 'text');
 		}
 
-		.o-footer__matrix-title:before,
-		.o-footer__matrix-title:after {
+		.o-footer__matrix-title,
+		.o-footer__matrix-title[aria-expanded] {
 			border-color: oColorsGetColorFor('o-footer-light', 'border');
 		}
 


### PR DESCRIPTION
Couple of improvements:

- Add o-normalise to the demos
- adjust spacing around footer navigation items so the link text is more centred in the touch target
- change border colours and styles for the bottom links on mobile so they're consistent
- add tabindex=1 to collapsible headings so you can keyboard tab to them

## before
![screen shot 2017-11-14 at 11 50 40](https://user-images.githubusercontent.com/68009/32778538-38522bb0-c932-11e7-8c25-d002aba4c64c.png)

## after
![screen shot 2017-11-14 at 11 49 23](https://user-images.githubusercontent.com/68009/32778533-336995f2-c932-11e7-8f04-d3c38ce17048.png)
![screen shot 2017-11-14 at 11 49 37](https://user-images.githubusercontent.com/68009/32778535-3542b656-c932-11e7-929e-c53746f39599.png)
