### PR TITLE
Make the footer margin optional.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ $o-footer-is-silent: false;
 // Output the simple footer, with the dark theme.
 // Use the method above for a light themed simple footer
 @include oFooter($simple: true);
+
+// Output o-footer without the standard top margin.
+@include oFooter($margin: false);
 ```
 
 ### JavaScript

--- a/src/scss/_footer.scss
+++ b/src/scss/_footer.scss
@@ -2,13 +2,16 @@
 ///
 /// @param {string} $theme ['dark'] - the theme of the footer styles requested
 /// @param {boolean} $simple [false] - whether to only output the default footer styles
-@mixin oFooter($theme: 'dark', $simple: false) {
+/// @param {boolean} $margin [false] - whether to output the standard footer margin or not
+@mixin oFooter($theme: 'dark', $simple: false, $margin: true) {
 	// required by o-grid JS helper
 	@include oGridSurfaceCurrentLayout();
 
 	.o-footer {
 		@include oTypographySans(0, 20px);
-		margin-top: (2 * $o-footer-spacing-unit);
+		@if $margin {
+			margin-top: (2 * $o-footer-spacing-unit);
+		}
 		line-height: $o-footer-spacing-unit;
 
 		a {


### PR DESCRIPTION
Adds a new argument to the mixin `oFooter` which when set to false will omit the standard footer margin. For context see: https://github.com/Financial-Times/o-footer/issues/91

Build service users should override the margin. In a future breaking, `o-footer` may omit the margin.

