### PR TITLE
Fix legal links issue in Safari

### DIFF
--- a/src/scss/_footer.scss
+++ b/src/scss/_footer.scss
@@ -32,6 +32,10 @@
 
 	.o-footer__legal-links {
 		padding-left: 0px;
+		
+		a {
+			display: inline-block;
+		}
 
 		li {
 			@include oTypographySans(-1);


### PR DESCRIPTION
Before:
<img src="https://user-images.githubusercontent.com/708296/57025293-a5f36d00-6c2e-11e9-80d3-ecba7917bb85.png">

After:
<img src="https://user-images.githubusercontent.com/708296/57025304-ad1a7b00-6c2e-11e9-8666-0c2da11cd04d.png">