### PR TITLE
Remove `role="contentinfo"` from o-footer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The basic structure of a simple footer has a theme and includes legal links, a c
 				<li><a href="#"><!-- legal link 3--></a></li>
 			</ul>
 		</div>
-		<div class="o-footer__copyright" role="contentinfo">
+		<div class="o-footer__copyright">
 			<small>
 				<!-- copyright notice -->
 			</small>
@@ -107,7 +107,7 @@ The width of the columns and the way they collapse on smaller viewports may be c
 			</h6>
 		</div>
 
-		<div class="o-footer__copyright" role="contentinfo">
+		<div class="o-footer__copyright">
 			<small>
 				<!-- copyright notice -->
 			</small>

--- a/demos/src/footer.mustache
+++ b/demos/src/footer.mustache
@@ -26,7 +26,7 @@
 			</h6>
 		</div>
 
-		<div class="o-footer__copyright" role="contentinfo">
+		<div class="o-footer__copyright">
 			<small>
 				Markets data delayed by at least 15 minutes. &#169; THE FINANCIAL TIMES LTD {{copyrightYear}}.
 				<abbr title="Financial Times" aria-label="F T">FT</abbr> and ‘Financial Times’ are trademarks of The Financial Times Ltd.<br>

--- a/demos/src/pa11y.mustache
+++ b/demos/src/pa11y.mustache
@@ -25,7 +25,7 @@
 			</h6>
 		</div>
 
-		<div class="o-footer__copyright" role="contentinfo">
+		<div class="o-footer__copyright">
 			<small>
 				Markets data delayed by at least 15 minutes. &#169; THE FINANCIAL TIMES LTD {{copyrightYear}}.
 				<abbr title="Financial Times" aria-label="F T">FT</abbr> and ‘Financial Times’ are trademarks of The Financial Times Ltd.<br>
@@ -68,7 +68,7 @@
 			</h6>
 		</div>
 
-		<div class="o-footer__copyright" role="contentinfo">
+		<div class="o-footer__copyright">
 			<small>
 				Markets data delayed by at least 15 minutes. &#169; THE FINANCIAL TIMES LTD {{copyrightYear}}.
 				<abbr title="Financial Times" aria-label="F T">FT</abbr> and ‘Financial Times’ are trademarks of The Financial Times Ltd.<br>

--- a/demos/src/simple-footer.mustache
+++ b/demos/src/simple-footer.mustache
@@ -5,7 +5,7 @@
 				<li><a href="http://help.ft.com/help/legal-privacy/terms-conditions/">Terms &amp; Conditions</a></li><li><a href="http://help.ft.com/help/legal-privacy/privacy/">Privacy</a></li><li><a href="http://help.ft.com/help/legal-privacy/cookies/">Cookies</a></li><li><a href="http://help.ft.com/help/legal-privacy/copyright/copyright-policy/">Copyright</a></li>
 			</ul>
 		</div>
-		<div class="o-footer__copyright" role="contentinfo">
+		<div class="o-footer__copyright">
 			<small>
 				Markets data delayed by at least 15 minutes. &#169; THE FINANCIAL TIMES LTD {{copyrightYear}}.
 				<abbr title="Financial Times" aria-label="F T">FT</abbr> and ‘Financial Times’ are trademarks of The Financial Times Ltd.<br>

--- a/test/helpers/fixtures.js
+++ b/test/helpers/fixtures.js
@@ -98,7 +98,7 @@ function htmlCode () {
 				</h6>
 			</div>
 
-			<div class="o-footer__copyright" role="contentinfo">
+			<div class="o-footer__copyright">
 				<small>
 					Markets data delayed by at least 15 minutes. &#xA9; THE FINANCIAL TIMES LTD 2016.
 					<abbr title="Financial Times" aria-label="F T">FT</abbr> and &#x2020;Financial Times&#x2020; are trademarks of The Financial Times Ltd.<br>


### PR DESCRIPTION
The `footer` element already acts as a landmark with the same
purpose.

[See WAI-ARIA 1.1](https://www.w3.org/TR/wai-aria-1.1/#contentinfo):
>Within any document or application, the author SHOULD mark no more
>than one element with the contentinfo role.

[See MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Contentinfo_role):
>Using the \<footer\> element will automatically communicate a section
>has a role of contentinfo. Developers should always prefer using
>the correct semantic HTML element over using ARIA, making sure to
>test for known issues in VoiceOver.

https://github.com/Financial-Times/o-footer/issues/126