### PR TITLE
Stop using magic webpack imports

### DIFF
--- a/test/oFooter.test.js
+++ b/test/oFooter.test.js
@@ -1,6 +1,6 @@
-/* eslint-env mocha, sinon, proclaim */
-import proclaim from 'proclaim';
-import sinon from 'sinon/pkg/sinon';
+/* eslint-env mocha */
+/* global proclaim sinon */
+
 import * as fixtures from './helpers/fixtures';
 import Toggle from 'o-toggle';
 

--- a/test/origami.test.js
+++ b/test/origami.test.js
@@ -1,6 +1,6 @@
-/* eslint-env mocha, sinon, proclaim */
-import proclaim from 'proclaim';
-import sinon from 'sinon/pkg/sinon';
+/* eslint-env mocha */
+/* global proclaim sinon */
+
 import * as fixtures from './helpers/fixtures';
 
 import oFooter from './../main';


### PR DESCRIPTION
Stop using the magic imports for proclaim and sinon and pull them from the global because that's where Karma has added them. This is required for obt v10 to be released.