### PR TITLE
Use dummy navigation data in demos.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # o-footer [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](#licence)
 
-FT page footer component
+Master brand FT page footer component. See the [Origami Navigation Service](https://www.ft.com/__origami/service/navigation) to populate `o-footer` markup with real navigation data.
+
+_See [o-footer-services](https://registry.origami.ft.com/components/o-footer-services) for an alternate footer style for tools and specialist titles. _
+
 
 - [Markup](#markup)
 - [Sass](#sass)
@@ -11,7 +14,7 @@ FT page footer component
 
 ## Markup
 
-The basic structure of a simple footer has a theme and includes legal links, a copyright notice, and a logo:
+The basic structure of a simple footer has a theme and includes legal links, a copyright notice, and a logo. The demo on the component page does not use real navigation data as it may become out of date. See the [Origami Navigation Service](https://www.ft.com/__origami/service/navigation) to populate `o-footer` markup with real navigation data. The Origami Navigation Service is a JSON API which provides navigation structures for use across FT websites.
 
 ```html
 <footer class="o-footer o-footer--theme-dark" data-o-component="o-footer" data-o-footer--no-js="">

--- a/demos/src/footer-light.json
+++ b/demos/src/footer-light.json
@@ -2,14 +2,14 @@
 	"theme": "theme-light",
 	"matrix": [
 		{
-			"title": "Support",
+			"title": "xxxxxxx",
 			"items": [
 				{
-					"text": "Help",
+					"text": "xxxx",
 					"href": "//www.ft.com/help"
 				},
 				{
-					"text": "About Us",
+					"text": "xxxxx xx",
 					"href": "//www.ft.com/aboutus"
 				}
 			],
@@ -18,11 +18,11 @@
 			"columns": [
 				[
 					{
-						"text": "Help",
+						"text": "xxxx",
 						"href": "//www.ft.com/help"
 					},
 					{
-						"text": "About Us",
+						"text": "xxxxx xx",
 						"href": "//www.ft.com/aboutus"
 					}
 				]
@@ -30,22 +30,22 @@
 			"collapsible": false
 		},
 		{
-			"title": "Legal & Privacy",
+			"title": "xxxxx x xxxxxxx",
 			"items": [
 				{
-					"text": "Terms & Conditions",
+					"text": "xxxxx x xxxxxxxxxx",
 					"href": "//www.ft.com/servicestools/help/terms"
 				},
 				{
-					"text": "Privacy",
+					"text": "xxxxxxx",
 					"href": "//www.ft.com/servicestools/help/privacy"
 				},
 				{
-					"text": "Cookies",
+					"text": "xxxxxxx",
 					"href": "//www.ft.com/cookiepolicy"
 				},
 				{
-					"text": "Copyright",
+					"text": "xxxxxxxxx",
 					"href": "//www.ft.com/servicestools/help/copyright"
 				}
 			],
@@ -54,19 +54,19 @@
 			"columns": [
 				[
 					{
-						"text": "Terms & Conditions",
+						"text": "xxxxx x xxxxxxxxxx",
 						"href": "//www.ft.com/servicestools/help/terms"
 					},
 					{
-						"text": "Privacy",
+						"text": "xxxxxxx",
 						"href": "//www.ft.com/servicestools/help/privacy"
 					},
 					{
-						"text": "Cookies",
+						"text": "xxxxxxx",
 						"href": "//www.ft.com/cookiepolicy"
 					},
 					{
-						"text": "Copyright",
+						"text": "xxxxxxxxx",
 						"href": "//www.ft.com/servicestools/help/copyright"
 					}
 				]
@@ -74,39 +74,39 @@
 			"collapsible": false
 		},
 		{
-			"title": "Services",
+			"title": "xxxxxxxx",
 			"items": [
 				{
-					"text": "Individual Subscriptions",
+					"text": "xxxxxxxxxx xxxxxxxxxxxxx",
 					"href": "//sub.ft.com/spa_5"
 				},
 				{
-					"text": "Group Subscriptions",
+					"text": "xxxxx xxxxxxxxxxxxx",
 					"href": "//enterprise.ft.com/en-gb/services/group-subscriptions/"
 				},
 				{
-					"text": "Republishing",
+					"text": "xxxxxxxxxxxx",
 					"href": "//enterprise.ft.com/en-gb/services/republishing/"
 				},
 				{
-					"text": "Contracts & Tenders",
+					"text": "xxxxxxxxx x xxxxxxx",
 					"href": "//www.businessesforsale.com/ft2/notices"
 				},
 				{
-					"text": "Analysts Research",
+					"text": "xxxxxxxx xxxxxxxx",
 					"href": "//commerce.uk.reuters.com/purchase/mostPopular.do?rpc&#x3D;471"
 				},
 				{
-					"text": "Executive Job Search",
+					"text": "xxxxxxxxx xxx xxxxxx",
 					"href": "//www.exec-appointments.com/"
 				},
 				{
-					"text": "Advertise with the FT",
+					"text": "xxxxxxxxx xxxx xxx xx",
 					"href": "//fttoolkit.co.uk/d/",
 					"aria-label": "Advertise with the F T"
 				},
 				{
-					"text": "Follow the FT on Twitter",
+					"text": "xxxxxx xxx xx xx xxxxxxx",
 					"href": "//twitter.com/ft",
 					"aria-label": "Follow the F T on Twitter"
 				}
@@ -116,38 +116,38 @@
 			"columns": [
 				[
 					{
-						"text": "Individual Subscriptions",
+						"text": "xxxxxxxxxx xxxxxxxxxxxxx",
 						"href": "//sub.ft.com/spa_5"
 					},
 					{
-						"text": "Group Subscriptions",
+						"text": "xxxxx xxxxxxxxxxxxx",
 						"href": "//enterprise.ft.com/en-gb/services/group-subscriptions/"
 					},
 					{
-						"text": "Republishing",
+						"text": "xxxxxxxxxxxx",
 						"href": "//enterprise.ft.com/en-gb/services/republishing/"
 					},
 					{
-						"text": "Contracts & Tenders",
+						"text": "xxxxxxxxx x xxxxxxx",
 						"href": "//www.businessesforsale.com/ft2/notices"
 					},
 					{
-						"text": "Analysts Research",
+						"text": "xxxxxxxx xxxxxxxx",
 						"href": "//commerce.uk.reuters.com/purchase/mostPopular.do?rpc&#x3D;471"
 					}
 				],
 				[
 					{
-						"text": "Executive Job Search",
+						"text": "xxxxxxxxx xxx xxxxxx",
 						"href": "//www.exec-appointments.com/"
 					},
 					{
-						"text": "Advertise with the FT",
+						"text": "xxxxxxxxx xxxx xxx xx",
 						"href": "//fttoolkit.co.uk/d/",
 						"aria-label": "Advertise with the F T"
 					},
 					{
-						"text": "Follow the FT on Twitter",
+						"text": "xxxxxx xxx xx xx xxxxxxx",
 						"href": "//twitter.com/ft",
 						"aria-label": "Follow the F T on Twitter"
 					}
@@ -156,42 +156,42 @@
 			"collapsible": true
 		},
 		{
-			"title": "Tools",
+			"title": "xxxxx",
 			"items": [
 				{
-					"text": "Portfolio",
+					"text": "xxxxxxxxx",
 					"href": "//markets.ft.com/data/portfolio/dashboard"
 				},
 				{
-					"text": "Today's Paper",
+					"text": "xxxxxxx xxxxx",
 					"href": "//ftepaper.ft.com"
 				},
 				{
-					"text": "Alerts Hub",
+					"text": "xxxxxx xxx",
 					"href": "//markets.ft.com/data/alerts/"
 				},
 				{
-					"text": "Lexicon",
+					"text": "xxxxxxx",
 					"href": "//lexicon.ft.com/"
 				},
 				{
-					"text": "MBA Rankings",
+					"text": "xxx xxxxxxxx",
 					"href": "//rankings.ft.com/businessschoolrankings/global-mba-ranking-2016"
 				},
 				{
-					"text": "Economic Calendar",
+					"text": "xxxxxxxx xxxxxxxx",
 					"href": "//markets.ft.com/Research/Economic-Calendar"
 				},
 				{
-					"text": "Newsletters",
+					"text": "xxxxxxxxxxx",
 					"href": "//nbe.ft.com/nbe/profile.cfm"
 				},
 				{
-					"text": "Currency Converter",
+					"text": "xxxxxxxx xxxxxxxxx",
 					"href": "//markets.ft.com/research/Markets/Currencies?segid&#x3D;70113"
 				},
 				{
-					"text": "Ebooks",
+					"text": "xxxxxx",
 					"href": "//www.ft.com/ebooks",
 					"aria-label": "E-books"
 				}
@@ -201,41 +201,41 @@
 			"columns": [
 				[
 					{
-						"text": "Portfolio",
+						"text": "xxxxxxxxx",
 						"href": "//markets.ft.com/data/portfolio/dashboard"
 					},
 					{
-						"text": "Today's Paper",
+						"text": "xxxxxxx xxxxx",
 						"href": "//ftepaper.ft.com"
 					},
 					{
-						"text": "Alerts Hub",
+						"text": "xxxxxx xxx",
 						"href": "//markets.ft.com/data/alerts/"
 					},
 					{
-						"text": "Lexicon",
+						"text": "xxxxxxx",
 						"href": "//lexicon.ft.com/"
 					},
 					{
-						"text": "MBA Rankings",
+						"text": "xxx xxxxxxxx",
 						"href": "//rankings.ft.com/businessschoolrankings/global-mba-ranking-2016"
 					}
 				],
 				[
 					{
-						"text": "Economic Calendar",
+						"text": "xxxxxxxx xxxxxxxx",
 						"href": "//markets.ft.com/Research/Economic-Calendar"
 					},
 					{
-						"text": "Newsletters",
+						"text": "xxxxxxxxxxx",
 						"href": "//nbe.ft.com/nbe/profile.cfm"
 					},
 					{
-						"text": "Currency Converter",
+						"text": "xxxxxxxx xxxxxxxxx",
 						"href": "//markets.ft.com/research/Markets/Currencies?segid&#x3D;70113"
 					},
 					{
-						"text": "Ebooks",
+						"text": "xxxxxx",
 						"href": "//www.ft.com/ebooks",
 						"aria-label": "E-books"
 					}

--- a/demos/src/footer.json
+++ b/demos/src/footer.json
@@ -2,14 +2,14 @@
 	"theme": "theme-dark",
 	"matrix": [
 		{
-			"title": "Support",
+			"title": "xxxxxxx",
 			"items": [
 				{
-					"text": "Help",
+					"text": "xxxx",
 					"href": "//www.ft.com/help"
 				},
 				{
-					"text": "About Us",
+					"text": "xxxxx xx",
 					"href": "//www.ft.com/aboutus"
 				}
 			],
@@ -18,11 +18,11 @@
 			"columns": [
 				[
 					{
-						"text": "Help",
+						"text": "xxxx",
 						"href": "//www.ft.com/help"
 					},
 					{
-						"text": "About Us",
+						"text": "xxxxx xx",
 						"href": "//www.ft.com/aboutus"
 					}
 				]
@@ -30,26 +30,26 @@
 			"collapsible": false
 		},
 		{
-			"title": "Legal & Privacy",
+			"title": "xxxxx x xxxxxxx",
 			"items": [
 				{
-					"text": "Terms & Conditions",
+					"text": "xxxxx x xxxxxxxxxx",
 					"href": "//www.ft.com/servicestools/help/terms"
 				},
 				{
-					"text": "Privacy",
+					"text": "xxxxxxx",
 					"href": "//www.ft.com/servicestools/help/privacy"
 				},
 				{
-					"text": "Cookies",
+					"text": "xxxxxxx",
 					"href": "//www.ft.com/cookiepolicy"
 				},
 				{
-					"text": "Copyright",
+					"text": "xxxxxxxxx",
 					"href": "//www.ft.com/servicestools/help/copyright"
 				},
 				{
-					"text": "Slavery Statement & Policies",
+					"text": "xxxxxxx xxxxxxxxx x xxxxxxxx",
 					"href": "//help.ft.com/help/legal/slavery-statement/"
 				}
 			],
@@ -58,19 +58,19 @@
 			"columns": [
 				[
 					{
-						"text": "Terms & Conditions",
+						"text": "xxxxx x xxxxxxxxxx",
 						"href": "//www.ft.com/servicestools/help/terms"
 					},
 					{
-						"text": "Privacy",
+						"text": "xxxxxxx",
 						"href": "//www.ft.com/servicestools/help/privacy"
 					},
 					{
-						"text": "Cookies",
+						"text": "xxxxxxx",
 						"href": "//www.ft.com/cookiepolicy"
 					},
 					{
-						"text": "Copyright",
+						"text": "xxxxxxxxx",
 						"href": "//www.ft.com/servicestools/help/copyright"
 					}
 				]
@@ -78,39 +78,39 @@
 			"collapsible": false
 		},
 		{
-			"title": "Services",
+			"title": "xxxxxxxx",
 			"items": [
 				{
-					"text": "Individual Subscriptions",
+					"text": "xxxxxxxxxx xxxxxxxxxxxxx",
 					"href": "//sub.ft.com/spa_5"
 				},
 				{
-					"text": "Group Subscriptions",
+					"text": "xxxxx xxxxxxxxxxxxx",
 					"href": "//enterprise.ft.com/en-gb/services/group-subscriptions/"
 				},
 				{
-					"text": "Republishing",
+					"text": "xxxxxxxxxxxx",
 					"href": "//enterprise.ft.com/en-gb/services/republishing/"
 				},
 				{
-					"text": "Contracts & Tenders",
+					"text": "xxxxxxxxx x xxxxxxx",
 					"href": "//www.businessesforsale.com/ft2/notices"
 				},
 				{
-					"text": "Analysts Research",
+					"text": "xxxxxxxx xxxxxxxx",
 					"href": "//commerce.uk.reuters.com/purchase/mostPopular.do?rpc&#x3D;471"
 				},
 				{
-					"text": "Executive Job Search",
+					"text": "xxxxxxxxx xxx xxxxxx",
 					"href": "//www.exec-appointments.com/"
 				},
 				{
-					"text": "Advertise with the FT",
+					"text": "xxxxxxxxx xxxx xxx xx",
 					"href": "//fttoolkit.co.uk/d/",
 					"aria-label": "Advertise with the F T"
 				},
 				{
-					"text": "Follow the FT on Twitter",
+					"text": "xxxxxx xxx xx xx xxxxxxx",
 					"href": "//twitter.com/ft",
 					"aria-label": "Follow the F T on Twitter"
 				}
@@ -120,38 +120,38 @@
 			"columns": [
 				[
 					{
-						"text": "Individual Subscriptions",
+						"text": "xxxxxxxxxx xxxxxxxxxxxxx",
 						"href": "//sub.ft.com/spa_5"
 					},
 					{
-						"text": "Group Subscriptions",
+						"text": "xxxxx xxxxxxxxxxxxx",
 						"href": "//enterprise.ft.com/en-gb/services/group-subscriptions/"
 					},
 					{
-						"text": "Republishing",
+						"text": "xxxxxxxxxxxx",
 						"href": "//enterprise.ft.com/en-gb/services/republishing/"
 					},
 					{
-						"text": "Contracts & Tenders",
+						"text": "xxxxxxxxx x xxxxxxx",
 						"href": "//www.businessesforsale.com/ft2/notices"
 					},
 					{
-						"text": "Analysts Research",
+						"text": "xxxxxxxx xxxxxxxx",
 						"href": "//commerce.uk.reuters.com/purchase/mostPopular.do?rpc&#x3D;471"
 					}
 				],
 				[
 					{
-						"text": "Executive Job Search",
+						"text": "xxxxxxxxx xxx xxxxxx",
 						"href": "//www.exec-appointments.com/"
 					},
 					{
-						"text": "Advertise with the FT",
+						"text": "xxxxxxxxx xxxx xxx xx",
 						"href": "//fttoolkit.co.uk/d/",
 						"aria-label": "Advertise with the F T"
 					},
 					{
-						"text": "Follow the FT on Twitter",
+						"text": "xxxxxx xxx xx xx xxxxxxx",
 						"href": "//twitter.com/ft",
 						"aria-label": "Follow the F T on Twitter"
 					}
@@ -160,42 +160,42 @@
 			"collapsible": true
 		},
 		{
-			"title": "Tools",
+			"title": "xxxxx",
 			"items": [
 				{
-					"text": "Portfolio",
+					"text": "xxxxxxxxx",
 					"href": "//markets.ft.com/data/portfolio/dashboard"
 				},
 				{
-					"text": "Today's Paper",
+					"text": "xxxxxxx xxxxx",
 					"href": "//ftepaper.ft.com"
 				},
 				{
-					"text": "Alerts Hub",
+					"text": "xxxxxx xxx",
 					"href": "//markets.ft.com/data/alerts/"
 				},
 				{
-					"text": "Lexicon",
+					"text": "xxxxxxx",
 					"href": "//lexicon.ft.com/"
 				},
 				{
-					"text": "MBA Rankings",
+					"text": "xxx xxxxxxxx",
 					"href": "//rankings.ft.com/businessschoolrankings/global-mba-ranking-2016"
 				},
 				{
-					"text": "Economic Calendar",
+					"text": "xxxxxxxx xxxxxxxx",
 					"href": "//markets.ft.com/Research/Economic-Calendar"
 				},
 				{
-					"text": "Newsletters",
+					"text": "xxxxxxxxxxx",
 					"href": "//nbe.ft.com/nbe/profile.cfm"
 				},
 				{
-					"text": "Currency Converter",
+					"text": "xxxxxxxx xxxxxxxxx",
 					"href": "//markets.ft.com/research/Markets/Currencies?segid&#x3D;70113"
 				},
 				{
-					"text": "Ebooks",
+					"text": "xxxxxx",
 					"href": "//www.ft.com/ebooks",
 					"aria-label": "E-books"
 				}
@@ -205,41 +205,41 @@
 			"columns": [
 				[
 					{
-						"text": "Portfolio",
+						"text": "xxxxxxxxx",
 						"href": "//markets.ft.com/data/portfolio/dashboard"
 					},
 					{
-						"text": "Today's Paper",
+						"text": "xxxxxxx xxxxx",
 						"href": "//ftepaper.ft.com"
 					},
 					{
-						"text": "Alerts Hub",
+						"text": "xxxxxx xxx",
 						"href": "//markets.ft.com/data/alerts/"
 					},
 					{
-						"text": "Lexicon",
+						"text": "xxxxxxx",
 						"href": "//lexicon.ft.com/"
 					},
 					{
-						"text": "MBA Rankings",
+						"text": "xxx xxxxxxxx",
 						"href": "//rankings.ft.com/businessschoolrankings/global-mba-ranking-2016"
 					}
 				],
 				[
 					{
-						"text": "Economic Calendar",
+						"text": "xxxxxxxx xxxxxxxx",
 						"href": "//markets.ft.com/Research/Economic-Calendar"
 					},
 					{
-						"text": "Newsletters",
+						"text": "xxxxxxxxxxx",
 						"href": "//nbe.ft.com/nbe/profile.cfm"
 					},
 					{
-						"text": "Currency Converter",
+						"text": "xxxxxxxx xxxxxxxxx",
 						"href": "//markets.ft.com/research/Markets/Currencies?segid&#x3D;70113"
 					},
 					{
-						"text": "Ebooks",
+						"text": "xxxxxx",
 						"href": "//www.ft.com/ebooks",
 						"aria-label": "E-books"
 					}

--- a/origami.json
+++ b/origami.json
@@ -39,14 +39,14 @@
 			"title": "Dark theme",
 			"template": "demos/src/footer.mustache",
 			"data": "demos/src/footer.json",
-			"description": "This is the standard masterbrand footer used on most pages."
+			"description": "This is the standard masterbrand footer used on most pages. Use the Origami Navigation Service to populate o-footer with real navigation data. "
 		},
 		{
 			"name": "footer-light",
 			"title": "Light theme",
 			"template": "demos/src/footer.mustache",
 			"data": "demos/src/footer-light.json",
-			"description": "A light theme masterbrand footer"
+			"description": "A light theme masterbrand footer. Use the Origami Navigation Service to populate o-footer with real navigation data. "
 		},
 		{
 			"name": "simple-footer",


### PR DESCRIPTION
Users copy and paste from o-footer demos and use out of date
navigation within their project. We considered populating
o-footer demos using Origami Navigation Service data but do
not want users to copy/paste static navigation which will not
update.

Addresses: https://github.com/Financial-Times/o-footer/issues/81
Relates to o-header issue: https://github.com/Financial-Times/o-header/issues/160
Relates to: https://github.com/Financial-Times/origami-build-tools/pull/718

<img width="1552" alt="Screenshot 2020-06-11 at 14 39 10" src="https://user-images.githubusercontent.com/10405691/84392121-d6f3ee80-abf1-11ea-8b9d-3319ce473e34.png">
<img width="1552" alt="Screenshot 2020-06-11 at 14 39 15" src="https://user-images.githubusercontent.com/10405691/84392124-d78c8500-abf1-11ea-801d-43d461b6871c.png">
<img width="1552" alt="Screenshot 2020-06-11 at 14 39 18" src="https://user-images.githubusercontent.com/10405691/84392126-d8bdb200-abf1-11ea-97e6-62ca2eb26ae2.png">
