### PR TITLE
Fix external links focus outline not showing

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -72,10 +72,42 @@
 		}
 	}
 
+	.o-footer__copyright {
+		margin-top: $_o-footer-spacing-unit;
+		margin-bottom: $_o-footer-spacing-unit;
+
+		a {
+			text-decoration: underline;
+		}
+	}
+
+	.o-footer__brand {
+		padding-top: oSpacingByName('s4');
+		padding-bottom: oSpacingByName('s4');
+	}
+
+	.o-footer__brand-logo {
+		@include _oFooterBrandImage('brand-nikkei-tagline', 200);
+		height: 20px;
+		background-repeat: no-repeat;
+		background-position: right;
+	}
+
+	@media print {
+		.o-footer {
+			display: none;
+		}
+	}
+
+	@if $matrix {
+		@include _oFooterMatrix($themes);
+	}
+
 	.o-footer__external-link {
 		position: relative;
 		border-top: 1px solid;
 		border-bottom: 1px solid;
+		// Ensure focus outline is visible.
 		overflow: visible;
 
 		&:after,
@@ -107,37 +139,6 @@
 				content: ' ';
 			}
 		}
-	}
-
-	.o-footer__copyright {
-		margin-top: $_o-footer-spacing-unit;
-		margin-bottom: $_o-footer-spacing-unit;
-
-		a {
-			text-decoration: underline;
-		}
-	}
-
-	.o-footer__brand {
-		padding-top: oSpacingByName('s4');
-		padding-bottom: oSpacingByName('s4');
-	}
-
-	.o-footer__brand-logo {
-		@include _oFooterBrandImage('brand-nikkei-tagline', 200);
-		height: 20px;
-		background-repeat: no-repeat;
-		background-position: right;
-	}
-
-	@media print {
-		.o-footer {
-			display: none;
-		}
-	}
-
-	@if $matrix {
-		@include _oFooterMatrix($themes);
 	}
 
 	// Include the themes


### PR DESCRIPTION
Make sure that when a user tabs to the link in the footer they know where they are by showing a focus outline.

| Before | After |
| - | - |
| <img width="258" alt="focused link in footer no visible focus outline" src="https://user-images.githubusercontent.com/2445413/84504819-81cce100-acb4-11ea-95ea-473294d87eb6.png"> | <img width="207" alt="focused link in footer with visible focus outline" src="https://user-images.githubusercontent.com/2445413/84504822-82657780-acb4-11ea-8778-03dd839c300c.png"> |


https://www.w3.org/WAI/WCAG21/Understanding/focus-visible.html

The external link contains an override to the overflow. So needs to be after the regular matrix mixin.

Jira: CPP-115

DAC ID: DAC_Missing_Visible_Focus_Indicator_Issue1