### PR TITLE
add extension to relative imports to make the code work directly in a browser

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-import Footer from './src/js/footer';
+import Footer from './src/js/footer.js';
 
 const constructAll = () => {
 	Footer.init();

--- a/src/js/footer.js
+++ b/src/js/footer.js
@@ -1,5 +1,5 @@
 import Toggle from 'o-toggle';
-import layout from './layout';
+import layout from './layout.js';
 
 
 const COLLAPSIBLE_BREAKPOINTS = ['default', 'XS', 'S'];

--- a/test/oFooter.test.js
+++ b/test/oFooter.test.js
@@ -1,10 +1,10 @@
 /* eslint-env mocha */
 /* global proclaim sinon */
 
-import * as fixtures from './helpers/fixtures';
+import * as fixtures from './helpers/fixtures.js';
 import Toggle from 'o-toggle';
 
-import oFooter from './../main';
+import oFooter from './../main.js';
 
 describe("oFooter", () => {
 

--- a/test/origami.test.js
+++ b/test/origami.test.js
@@ -1,9 +1,9 @@
 /* eslint-env mocha */
 /* global proclaim sinon */
 
-import * as fixtures from './helpers/fixtures';
+import * as fixtures from './helpers/fixtures.js';
 
-import oFooter from './../main';
+import oFooter from './../main.js';
 
 describe("oFooter", () => {
 	it('is defined', () => {


### PR DESCRIPTION
relative imports require the full path including the extension because browsers use the import name to make a network request and they do not implicitly add a .js file extension if one is missing