### PR TITLE
Add 2 extra columns to o-footer, one for Community Events and More from FT

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -41,7 +41,7 @@ Support for Bower and version 2 of the Origami Build Service have been removed.
 
 Follow [the migration guide on the Origami website](https://origami.ft.com/docs/tutorials/bower-to-npm/).
 
-_Note: If you are not able to upgrade to `v8` immediately, you may temporarily skip this upgrade and instead [upgrade to `v9.0.0-bower`](MIGRATION.md#migrating-from-v8-to-v9). `v9.0.0` introduces new features which are backported in `v9.0.0-bower` to support Bower and version 2 of the Origami Build Service. We do not recommend this as you may miss future updates, and will be required to upgrade fully eventually._
+_Note: If you are not able to upgrade to `v8` immediately, you may temporarily skip this upgrade and instead [upgrade to `v9.0.0-bower`](MIGRATION.md#migrating-from-v8-to-v9). `v9.0.0` introduces new features which are backported in `v9.0.0-bower` to support Bower and version 2 of the Origami Build Service. We do not recommend this as you may miss future updates, and will be [required to upgrade by July 2022](https://origami.ft.com/blog/2021/01/18/deprecating-bower-and-origami-via-npm/)._
 
 ## Migrating from v6 to v7
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,10 +1,47 @@
 # Migration guide
 
+## Migrating from v8 to v9
+
+Markup has been updated to support 2 extra columns of links, one for Community Events and another for "More from the FT Group". All nav items are now behind a dropdown on mobile devices.
+
+Update `o-footer` markup in your project according to the README and component demos. The changes are as follows:
+
+1. Each `o-footer__matrix-link` element must now include a child element `o-footer__matrix-link__copy`.
+```diff
+<a class="o-footer__matrix-link" href="#">
++        <span class="o-footer__matrix-link__copy"><!-- link 1 --></span>
+-        <!-- link 1 -->
+</a>
+```
+2. The markup for the "More from the FT Group" link has changed. It has been moved inside the `nav` element alongside other links, within  it's is matrix group. Unlink other matrix title element there is an extra class `o-footer__matrix-title--link`, to indicate the title contains a link. The link itself also has an extra class `o-footer__matrix-link--more`, which applies the right arrow, etc. Note in the diff below some classes such as `o-footer__more-from-ft` are deleted.
+```diff
+<!-- ... more o-footer markup ...  -->
+<nav>
+<!-- ... o-footer links ...  -->
++       <div class="o-footer__matrix-group o-footer__matrix-group--1">
++           <h3 class="o-footer__matrix-title o-footer__matrix-title--link">
++               <a class ='o-footer__matrix-link o-footer__matrix-link--more' id="o-footer-section-5" href="#">
++                   <span class="o-footer__matrix-link__copy"><!-- link  --></span>
++               </a>
++           </h3>
++       </div>
+</nav>
+-
+-<h3 class="o-footer__external-link o-footer__matrix-title">
+-        <a class="o-footer__more-from-ft o-footer__matrix-title" href="#"><!-- link --></a>
+-</h3>
+<!-- ... more o-footer markup ...  -->
+```
+
+_Note: These changes have also been released in `v9.0.0-bower`, a temporary backport which includes Bower and Origami Build Service v2 support which was dropped in v8. `v9.0.0-bower` is not recommended outside a temporary measure for those unable to complete the [v7 to v8 migration](MIGRATION.md#migrating-from-v7-to-v8) immediately._
+
 ## Migrating from v7 to v8
 
 Support for Bower and version 2 of the Origami Build Service have been removed.
 
 Follow [the migration guide on the Origami website](https://origami.ft.com/docs/tutorials/bower-to-npm/).
+
+_Note: If you are not able to upgrade to `v8` immediately, you may temporarily skip this upgrade and instead [upgrade to `v9.0.0-bower`](MIGRATION.md#migrating-from-v8-to-v9). `v9.0.0` introduces new features which are backported in `v9.0.0-bower` to support Bower and version 2 of the Origami Build Service. We do not recommend this as you may miss future updates, and will be required to upgrade fully eventually._
 
 ## Migrating from v6 to v7
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -13,7 +13,7 @@ Update `o-footer` markup in your project according to the README and component d
 -        <!-- link 1 -->
 </a>
 ```
-2. The markup for the "More from the FT Group" link has changed. It has been moved inside the `nav` element alongside other links, within  it's is matrix group. Unlink other matrix title element there is an extra class `o-footer__matrix-title--link`, to indicate the title contains a link. The link itself also has an extra class `o-footer__matrix-link--more`, which applies the right arrow, etc. Note in the diff below some classes such as `o-footer__more-from-ft` are deleted.
+2. The markup for the "More from the FT Group" link has changed. It has been moved inside the `nav` element alongside other links, within  it's matrix group. Unlike other matrix title elements there is an extra class `o-footer__matrix-title--link`, to indicate the title contains a link. The link itself also has an extra class `o-footer__matrix-link--more`, which applies the right arrow, etc. Note in the diff below some classes such as `o-footer__more-from-ft` are deleted.
 ```diff
 <!-- ... more o-footer markup ...  -->
 <nav>

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ The width of the columns and the way they collapse on smaller viewports may be c
 					</div>
 				</div>
 				<div class="o-footer__matrix-group o-footer__matrix-group--1">
-					<h3 class="o-footer__matrix-title o-footer__matrix-title--external-link">
+					<h3 class="o-footer__matrix-title o-footer__matrix-title--link">
 						<a class ='o-footer__matrix-link o-footer__matrix-link--more' id="o-footer-section-5" href="#">
 							<span class="o-footer__matrix-link__copy"><!-- link  --></span>
 						</a>

--- a/README.md
+++ b/README.md
@@ -204,7 +204,8 @@ document.addEventListener('DOMContentLoaded', function() {
 
 State | Major Version | Last Minor Release | Migration guide |
 :---: | :---: | :---: | :---:
-✨ active | 8 | N/A | [migrate to v8](MIGRATION.md#migrating-from-v7-to-v8) |
+✨ active | 9 | N/A | [migrate to v9](MIGRATION.md#migrating-from-v8-to-v9) |
+⚠ maintained | 8 | N/A | [migrate to v8](MIGRATION.md#migrating-from-v7-to-v8) |
 ⚠ maintained | 7 | 7.0.12 | [migrate to v7](MIGRATION.md#migrating-from-v6-to-v7) |
 ╳ deprecated | 6 | 6.1 | [migrate to v6](MIGRATION.md#migrating-from-v5-to-v6) |
 ╳ deprecated | 5 | 5.4 | [migrate to v5](MIGRATION.md#migrating-from-v4-to-v5) |

--- a/README.md
+++ b/README.md
@@ -74,8 +74,12 @@ The width of the columns and the way they collapse on smaller viewports may be c
 					</h3>
 					<div class="o-footer__matrix-content" id="o-footer-section-0">
 						<div class="o-footer__matrix-column">
-								<a class="o-footer__matrix-link" href="#"><!-- link 1 --></a>
-								<a class="o-footer__matrix-link" href="#"><!-- link 2 --></a>
+								<a class="o-footer__matrix-link" href="#">
+									<span class="o-footer__matrix-link__copy"><!-- link 1 --></span>
+								</a>
+								<a class="o-footer__matrix-link" href="#">
+									<span class="o-footer__matrix-link__copy"><!-- link 2 --></span>
+								</a>
 						</div>
 					</div>
 				</div>
@@ -86,8 +90,12 @@ The width of the columns and the way they collapse on smaller viewports may be c
 					</h3>
 					<div class="o-footer__matrix-content" id="o-footer-section-1">
 						<div class="o-footer__matrix-column">
-							<a class="o-footer__matrix-link" href="#"><!-- link 1 --></a>
-							<a class="o-footer__matrix-link" href="#"><!-- link 2 --></a>
+							<a class="o-footer__matrix-link" href="#">
+								<span class="o-footer__matrix-link__copy"><!-- link 1 --></span>
+							</a>
+							<a class="o-footer__matrix-link" href="#">
+								<span class="o-footer__matrix-link__copy"><!-- link 2 --></span>
+							</a>
 						</div>
 					</div>
 				</div>
@@ -98,18 +106,28 @@ The width of the columns and the way they collapse on smaller viewports may be c
 					</h3>
 					<div class="o-footer__matrix-content" id="o-footer-section-2">
 							<div class="o-footer__matrix-column">
-								<a class="o-footer__matrix-link" href="#"><!-- link 1 --></a>
-								<a class="o-footer__matrix-link" href="#"><!-- link 2 --></a>
+								<a class="o-footer__matrix-link" href="#">
+									<span class="o-footer__matrix-link__copy"><!-- link 1 --></span>
+								</a>
+								<a class="o-footer__matrix-link" href="#">
+									<span class="o-footer__matrix-link__copy"><!-- link 2 --></span>
+								</a>
 							</div>
 							<div class="o-footer__matrix-column">
-								<a class="o-footer__matrix-link" href="#"><!-- link 3 --></a>
-								<a class="o-footer__matrix-link" href="#"><!-- link 4 --></a>
+								<a class="o-footer__matrix-link" href="#">
+									<span class="o-footer__matrix-link__copy"><!-- link 3 --></span>
+								</a>
+								<a class="o-footer__matrix-link" href="#">
+									<span class="o-footer__matrix-link__copy"><!-- link 4 --></span>
+								</a>
 							</div>
 					</div>
 				</div>
 				<div class="o-footer__matrix-group o-footer__matrix-group--1">
 					<h3 class="o-footer__matrix-title o-footer__matrix-title--external-link">
-						<a class="o-footer__more-from-ft o-footer__matrix-title" href="#"><!-- link --></a>
+						<a class ='o-footer__matrix-link o-footer__matrix-link--more' id="o-footer-section-5" href="#">
+							<span class="o-footer__matrix-link__copy"><!-- link  --></span>
+						</a>
 					</h3>
 				</div>
 			</nav>

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ The width of the columns and the way they collapse on smaller viewports may be c
 					</div>
 				</div>
 
-				<div class="o-footer__matrix-group o-footer__matrix-group--2">
+				<div class="o-footer__matrix-group o-footer__matrix-group--1">
 					<h3 class="o-footer__matrix-title" aria-controls="o-footer-section-2">
 						Services
 					</h3>
@@ -107,11 +107,12 @@ The width of the columns and the way they collapse on smaller viewports may be c
 							</div>
 					</div>
 				</div>
+				<div class="o-footer__matrix-group o-footer__matrix-group--1">
+					<h3 class="o-footer__matrix-title o-footer__matrix-title--external-link">
+						<a class="o-footer__more-from-ft o-footer__matrix-title" href="#"><!-- link --></a>
+					</h3>
+				</div>
 			</nav>
-
-			<h3 class="o-footer__external-link o-footer__matrix-title">
-				<a class="o-footer__more-from-ft o-footer__matrix-title" href="#"><!-- link --></a>
-			</h3>
 		</div>
 
 		<div class="o-footer__copyright">

--- a/demos/src/footer-light.json
+++ b/demos/src/footer-light.json
@@ -193,7 +193,7 @@
 				]
 			],
 			"collapsible": true
-		},        
+		},
         {
             "title": "xxxxxxx",
             "items": [
@@ -240,5 +240,5 @@
         }
 
 	],
-	"copyrightYear": 2020
+	"copyrightYear": 2021
 }

--- a/demos/src/footer-light.json
+++ b/demos/src/footer-light.json
@@ -27,7 +27,7 @@
 					}
 				]
 			],
-			"collapsible": false
+			"collapsible": true
 		},
 		{
 			"title": "xxxxx x xxxxxxx",
@@ -71,7 +71,7 @@
 					}
 				]
 			],
-			"collapsible": false
+			"collapsible": true
 		},
 		{
 			"title": "xxxxxxxx",
@@ -95,24 +95,10 @@
 				{
 					"text": "xxxxxxxx xxxxxxxx",
 					"href": "//commerce.uk.reuters.com/purchase/mostPopular.do?rpc&#x3D;471"
-				},
-				{
-					"text": "xxxxxxxxx xxx xxxxxx",
-					"href": "//www.exec-appointments.com/"
-				},
-				{
-					"text": "xxxxxxxxx xxxx xxx xx",
-					"href": "//fttoolkit.co.uk/d/",
-					"aria-label": "Advertise with the F T"
-				},
-				{
-					"text": "xxxxxx xxx xx xx xxxxxxx",
-					"href": "//twitter.com/ft",
-					"aria-label": "Follow the F T on Twitter"
 				}
 			],
 			"index": 2,
-			"layout": 2,
+			"layout": 1,
 			"columns": [
 				[
 					{
@@ -134,22 +120,6 @@
 					{
 						"text": "xxxxxxxx xxxxxxxx",
 						"href": "//commerce.uk.reuters.com/purchase/mostPopular.do?rpc&#x3D;471"
-					}
-				],
-				[
-					{
-						"text": "xxxxxxxxx xxx xxxxxx",
-						"href": "//www.exec-appointments.com/"
-					},
-					{
-						"text": "xxxxxxxxx xxxx xxx xx",
-						"href": "//fttoolkit.co.uk/d/",
-						"aria-label": "Advertise with the F T"
-					},
-					{
-						"text": "xxxxxx xxx xx xx xxxxxxx",
-						"href": "//twitter.com/ft",
-						"aria-label": "Follow the F T on Twitter"
 					}
 				]
 			],
@@ -197,7 +167,7 @@
 				}
 			],
 			"index": 3,
-			"layout": 2,
+			"layout": 1,
 			"columns": [
 				[
 					{
@@ -220,29 +190,55 @@
 						"text": "xxx xxxxxxxx",
 						"href": "//rankings.ft.com/businessschoolrankings/global-mba-ranking-2016"
 					}
-				],
-				[
-					{
-						"text": "xxxxxxxx xxxxxxxx",
-						"href": "//markets.ft.com/Research/Economic-Calendar"
-					},
-					{
-						"text": "xxxxxxxxxxx",
-						"href": "//nbe.ft.com/nbe/profile.cfm"
-					},
-					{
-						"text": "xxxxxxxx xxxxxxxxx",
-						"href": "//markets.ft.com/research/Markets/Currencies?segid&#x3D;70113"
-					},
-					{
-						"text": "xxxxxx",
-						"href": "//www.ft.com/ebooks",
-						"aria-label": "E-books"
-					}
 				]
 			],
 			"collapsible": true
-		}
+		},        
+        {
+            "title": "xxxxxxx",
+            "items": [
+                {
+                    "text": "xxxxxxxxx",
+                    "href": "//markets.ft.com/data/portfolio/dashboard"
+                },
+                {
+                    "text": "xxxxxxx xxxxx",
+                    "href": "//ftepaper.ft.com"
+                },
+                {
+                    "text": "xxxxxx xxx",
+                    "href": "//markets.ft.com/data/alerts/"
+                },
+                {
+                    "text": "xxxxxxx",
+                    "href": "//lexicon.ft.com/"
+                }
+            ],
+            "index": 4,
+            "layout": 1,
+            "columns": [
+                [
+                    {
+                        "text": "xxxxxxxxx",
+                        "href": "//markets.ft.com/data/portfolio/dashboard"
+                    },
+                    {
+                        "text": "xxxxxxx xxxxx",
+                        "href": "//ftepaper.ft.com"
+                    },
+                    {
+                        "text": "xxxxxx xxx",
+                        "href": "//markets.ft.com/data/alerts/"
+                    },
+                    {
+                        "text": "xxxxxxx",
+                        "href": "//lexicon.ft.com/"
+                    }
+                ]
+            ],
+            "collapsible": true
+        }
+
 	],
 	"copyrightYear": 2020
 }

--- a/demos/src/footer.json
+++ b/demos/src/footer.json
@@ -193,7 +193,7 @@
 				]
 			],
 			"collapsible": true
-		},        
+		},
         {
             "title": "xxxxxxx",
             "items": [
@@ -240,5 +240,5 @@
         }
 
 	],
-	"copyrightYear": 2020
+	"copyrightYear": 2021
 }

--- a/demos/src/footer.json
+++ b/demos/src/footer.json
@@ -27,7 +27,7 @@
 					}
 				]
 			],
-			"collapsible": false
+			"collapsible": true
 		},
 		{
 			"title": "xxxxx x xxxxxxx",
@@ -47,10 +47,6 @@
 				{
 					"text": "xxxxxxxxx",
 					"href": "//www.ft.com/servicestools/help/copyright"
-				},
-				{
-					"text": "xxxxxxx xxxxxxxxx x xxxxxxxx",
-					"href": "//help.ft.com/help/legal/slavery-statement/"
 				}
 			],
 			"index": 1,
@@ -75,7 +71,7 @@
 					}
 				]
 			],
-			"collapsible": false
+			"collapsible": true
 		},
 		{
 			"title": "xxxxxxxx",
@@ -99,24 +95,10 @@
 				{
 					"text": "xxxxxxxx xxxxxxxx",
 					"href": "//commerce.uk.reuters.com/purchase/mostPopular.do?rpc&#x3D;471"
-				},
-				{
-					"text": "xxxxxxxxx xxx xxxxxx",
-					"href": "//www.exec-appointments.com/"
-				},
-				{
-					"text": "xxxxxxxxx xxxx xxx xx",
-					"href": "//fttoolkit.co.uk/d/",
-					"aria-label": "Advertise with the F T"
-				},
-				{
-					"text": "xxxxxx xxx xx xx xxxxxxx",
-					"href": "//twitter.com/ft",
-					"aria-label": "Follow the F T on Twitter"
 				}
 			],
 			"index": 2,
-			"layout": 2,
+			"layout": 1,
 			"columns": [
 				[
 					{
@@ -138,22 +120,6 @@
 					{
 						"text": "xxxxxxxx xxxxxxxx",
 						"href": "//commerce.uk.reuters.com/purchase/mostPopular.do?rpc&#x3D;471"
-					}
-				],
-				[
-					{
-						"text": "xxxxxxxxx xxx xxxxxx",
-						"href": "//www.exec-appointments.com/"
-					},
-					{
-						"text": "xxxxxxxxx xxxx xxx xx",
-						"href": "//fttoolkit.co.uk/d/",
-						"aria-label": "Advertise with the F T"
-					},
-					{
-						"text": "xxxxxx xxx xx xx xxxxxxx",
-						"href": "//twitter.com/ft",
-						"aria-label": "Follow the F T on Twitter"
 					}
 				]
 			],
@@ -201,7 +167,7 @@
 				}
 			],
 			"index": 3,
-			"layout": 2,
+			"layout": 1,
 			"columns": [
 				[
 					{
@@ -224,29 +190,55 @@
 						"text": "xxx xxxxxxxx",
 						"href": "//rankings.ft.com/businessschoolrankings/global-mba-ranking-2016"
 					}
-				],
-				[
-					{
-						"text": "xxxxxxxx xxxxxxxx",
-						"href": "//markets.ft.com/Research/Economic-Calendar"
-					},
-					{
-						"text": "xxxxxxxxxxx",
-						"href": "//nbe.ft.com/nbe/profile.cfm"
-					},
-					{
-						"text": "xxxxxxxx xxxxxxxxx",
-						"href": "//markets.ft.com/research/Markets/Currencies?segid&#x3D;70113"
-					},
-					{
-						"text": "xxxxxx",
-						"href": "//www.ft.com/ebooks",
-						"aria-label": "E-books"
-					}
 				]
 			],
 			"collapsible": true
-		}
+		},        
+        {
+            "title": "xxxxxxx",
+            "items": [
+                {
+                    "text": "xxxxxxxxx",
+                    "href": "//markets.ft.com/data/portfolio/dashboard"
+                },
+                {
+                    "text": "xxxxxxx xxxxx",
+                    "href": "//ftepaper.ft.com"
+                },
+                {
+                    "text": "xxxxxx xxx",
+                    "href": "//markets.ft.com/data/alerts/"
+                },
+                {
+                    "text": "xxxxxxx",
+                    "href": "//lexicon.ft.com/"
+                }
+            ],
+            "index": 4,
+            "layout": 1,
+            "columns": [
+                [
+                    {
+                        "text": "xxxxxxxxx",
+                        "href": "//markets.ft.com/data/portfolio/dashboard"
+                    },
+                    {
+                        "text": "xxxxxxx xxxxx",
+                        "href": "//ftepaper.ft.com"
+                    },
+                    {
+                        "text": "xxxxxx xxx",
+                        "href": "//markets.ft.com/data/alerts/"
+                    },
+                    {
+                        "text": "xxxxxxx",
+                        "href": "//lexicon.ft.com/"
+                    }
+                ]
+            ],
+            "collapsible": true
+        }
+
 	],
 	"copyrightYear": 2020
 }

--- a/demos/src/footer.mustache
+++ b/demos/src/footer.mustache
@@ -14,7 +14,9 @@
 						{{#columns}}
 							<div class="o-footer__matrix-column">
 								{{#.}}
-									<a class="o-footer__matrix-link" {{#aria-label}}aria-label="{{aria-label}}"{{/aria-label}} href="{{href}}">{{{text}}}</a>
+									<a class="o-footer__matrix-link" {{#aria-label}}aria-label="{{aria-label}}"{{/aria-label}} href="{{href}}">
+										<span class="o-footer__matrix-link__copy">{{{text}}}</span>
+									</a>
 								{{/.}}
 							</div>
 						{{/columns}}

--- a/demos/src/footer.mustache
+++ b/demos/src/footer.mustache
@@ -23,7 +23,9 @@
 				{{/matrix}}
 				<div class="o-footer__matrix-group o-footer__matrix-group--1">
 					<h3 class="o-footer__matrix-title o-footer__matrix-title--external-link">
-						<a class ='o-footer__matrix-link' id="o-footer-section-5" href="https://ft.com/more-from-ft-group">More from the FT Group &gt;</a>
+						<a class ='o-footer__matrix-link o-footer__matrix-link--more' id="o-footer-section-5" href="https://ft.com/more-from-ft-group">
+							<span class="o-footer__matrix-link__copy">More from the FT Group</span>
+						</a>
 					</h3>
 				</div>
 			</nav>

--- a/demos/src/footer.mustache
+++ b/demos/src/footer.mustache
@@ -21,11 +21,12 @@
 					</div>
 				</div>
 				{{/matrix}}
+				<div class="o-footer__matrix-group o-footer__matrix-group--1">
+					<h3 class="o-footer__matrix-title o-footer__matrix-title--external-link">
+						<a class ='o-footer__matrix-link' id="o-footer-section-5" href="https://ft.com/more-from-ft-group">More from the FT Group &gt;</a>
+					</h3>
+				</div>
 			</nav>
-
-			<h3 class="o-footer__external-link o-footer__matrix-title">
-				<a class ='o-footer__more-from-ft o-footer__matrix-title' href="http://ft.com/more-from-ft-group">More from the FT Group</a>
-			</h3>
 		</div>
 
 		<div class="o-footer__copyright">

--- a/demos/src/footer.mustache
+++ b/demos/src/footer.mustache
@@ -24,7 +24,7 @@
 				</div>
 				{{/matrix}}
 				<div class="o-footer__matrix-group o-footer__matrix-group--1">
-					<h3 class="o-footer__matrix-title o-footer__matrix-title--external-link">
+					<h3 class="o-footer__matrix-title o-footer__matrix-title--link">
 						<a class ='o-footer__matrix-link o-footer__matrix-link--more' id="o-footer-section-5" href="https://ft.com/more-from-ft-group">
 							<span class="o-footer__matrix-link__copy">More from the FT Group</span>
 						</a>

--- a/demos/src/pa11y.mustache
+++ b/demos/src/pa11y.mustache
@@ -25,7 +25,7 @@
 				{{/matrix}}
 				<div class="o-footer__matrix-group o-footer__matrix-group--1">
 					<h3 class="o-footer__matrix-title o-footer__matrix-title--link">
-						<a class ='o-footer__matrix-link o-footer__matrix-link--more' id="o-footer-section-5" href="https://ft.com/more-from-ft-group">
+						<a class ='o-footer__matrix-link o-footer__matrix-link--more' id="o-footer-section-light-5" href="https://ft.com/more-from-ft-group">
 							<span class="o-footer__matrix-link__copy">More from the FT Group</span>
 						</a>
 					</h3>
@@ -76,7 +76,7 @@
 				{{/matrix}}
 				<div class="o-footer__matrix-group o-footer__matrix-group--1">
 					<h3 class="o-footer__matrix-title o-footer__matrix-title--link">
-						<a class ='o-footer__matrix-link o-footer__matrix-link--more' id="o-footer-section-5" href="https://ft.com/more-from-ft-group">
+						<a class ='o-footer__matrix-link o-footer__matrix-link--more' id="o-footer-section-dark-5" href="https://ft.com/more-from-ft-group">
 							<span class="o-footer__matrix-link__copy">More from the FT Group</span>
 						</a>
 					</h3>

--- a/demos/src/pa11y.mustache
+++ b/demos/src/pa11y.mustache
@@ -1,4 +1,4 @@
-<footer class="o-footer o-footer--light" data-o-component="o-footer" data-o-footer--no-js>
+<footer class="o-footer o-footer--theme-light" data-o-component="o-footer" data-o-footer--no-js>
 	<div class="o-footer__container">
 
 		<h2 class="o-footer-visually-hidden">Useful links</h2>
@@ -14,18 +14,23 @@
 						{{#columns}}
 							<div class="o-footer__matrix-column">
 								{{#.}}
-									<a class="o-footer__matrix-link" {{#aria-label}}aria-label="{{aria-label}}"{{/aria-label}} href="{{href}}">{{{text}}}</a>
+									<a class="o-footer__matrix-link" {{#aria-label}}aria-label="{{aria-label}}"{{/aria-label}} href="{{href}}">
+										<span class="o-footer__matrix-link__copy">{{{text}}}</span>
+									</a>
 								{{/.}}
 							</div>
 						{{/columns}}
 					</div>
 				</div>
 				{{/matrix}}
+				<div class="o-footer__matrix-group o-footer__matrix-group--1">
+					<h3 class="o-footer__matrix-title o-footer__matrix-title--external-link">
+						<a class ='o-footer__matrix-link o-footer__matrix-link--more' id="o-footer-section-5" href="https://ft.com/more-from-ft-group">
+							<span class="o-footer__matrix-link__copy">More from the FT Group</span>
+						</a>
+					</h3>
+				</div>
 			</nav>
-
-			<h3 class="o-footer__external-link o-footer__matrix-title">
-				<a class ='o-footer__more-from-ft o-footer__matrix-title' href="http://ft.com/more-from-ft-group">More from the FT Group</a>
-			</h3>
 		</div>
 
 		<div class="o-footer__copyright">
@@ -44,7 +49,7 @@
 	</div>
 </footer>
 
-<footer class="o-footer o-footer--dark" data-o-component="o-footer" data-o-footer--no-js>
+<footer class="o-footer o-footer--theme-dark" data-o-component="o-footer" data-o-footer--no-js>
 	<div class="o-footer__container">
 
 		<h2 class="o-footer-visually-hidden">Useful links</h2>
@@ -60,18 +65,23 @@
 						{{#columns}}
 							<div class="o-footer__matrix-column">
 								{{#.}}
-									<a class="o-footer__matrix-link" {{#aria-label}}aria-label="{{aria-label}}"{{/aria-label}} href="{{href}}">{{{text}}}</a>
+									<a class="o-footer__matrix-link" {{#aria-label}}aria-label="{{aria-label}}"{{/aria-label}} href="{{href}}">
+										<span class="o-footer__matrix-link__copy">{{{text}}}</span>
+									</a>
 								{{/.}}
 							</div>
 						{{/columns}}
 					</div>
 				</div>
 				{{/matrix}}
+				<div class="o-footer__matrix-group o-footer__matrix-group--1">
+					<h3 class="o-footer__matrix-title o-footer__matrix-title--external-link">
+						<a class ='o-footer__matrix-link o-footer__matrix-link--more' id="o-footer-section-5" href="https://ft.com/more-from-ft-group">
+							<span class="o-footer__matrix-link__copy">More from the FT Group</span>
+						</a>
+					</h3>
+				</div>
 			</nav>
-
-			<h3 class="o-footer__external-link o-footer__matrix-title">
-				<a class ='o-footer__more-from-ft o-footer__matrix-title' href="http://ft.com/more-from-ft-group">More from the FT Group</a>
-			</h3>
 		</div>
 
 		<div class="o-footer__copyright">

--- a/demos/src/pa11y.mustache
+++ b/demos/src/pa11y.mustache
@@ -24,7 +24,7 @@
 				</div>
 				{{/matrix}}
 				<div class="o-footer__matrix-group o-footer__matrix-group--1">
-					<h3 class="o-footer__matrix-title o-footer__matrix-title--external-link">
+					<h3 class="o-footer__matrix-title o-footer__matrix-title--link">
 						<a class ='o-footer__matrix-link o-footer__matrix-link--more' id="o-footer-section-5" href="https://ft.com/more-from-ft-group">
 							<span class="o-footer__matrix-link__copy">More from the FT Group</span>
 						</a>
@@ -75,7 +75,7 @@
 				</div>
 				{{/matrix}}
 				<div class="o-footer__matrix-group o-footer__matrix-group--1">
-					<h3 class="o-footer__matrix-title o-footer__matrix-title--external-link">
+					<h3 class="o-footer__matrix-title o-footer__matrix-title--link">
 						<a class ='o-footer__matrix-link o-footer__matrix-link--more' id="o-footer-section-5" href="https://ft.com/more-from-ft-group">
 							<span class="o-footer__matrix-link__copy">More from the FT Group</span>
 						</a>

--- a/main.scss
+++ b/main.scss
@@ -102,44 +102,6 @@
 		@include _oFooterMatrix($themes);
 	}
 
-	.o-footer__external-link {
-		position: relative;
-		border-top: 1px solid;
-		border-bottom: 1px solid;
-		// Ensure focus outline is visible.
-		overflow: visible;
-
-		&:after,
-		&:before {
-			content: '';
-			display: block;
-			position: absolute;
-			width: 100vw;
-			left: 50%;
-			margin-left: -50vw;
-		}
-
-		&:before {
-			top: 0;
-		}
-
-		&:after {
-			bottom: 0;
-		}
-
-		a {
-			padding-top: oSpacingByName('s3');
-			padding-bottom: oSpacingByName('s3');
-			display: block;
-
-			&:after {
-				@include oIconsContent('arrow-right', _oFooterGet('title'), $size: $_o-footer-icon-size);
-				vertical-align: middle;
-				content: ' ';
-			}
-		}
-	}
-
 	// Include the themes
 	@each $theme in $themes {
 		@include _oFooterTheme($theme);

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -42,7 +42,7 @@
 			}
 		}
 
-		.o-footer__matrix-title--external-link,
+		.o-footer__matrix-title--link,
 		.o-footer__matrix-title[aria-expanded] {
 			border-color: _oFooterGet('border', $from: $theme);
 		}
@@ -137,7 +137,8 @@
 		}
 	}
 
-	.o-footer__matrix-title--external-link {
+	// I.e. `.o-footer__matrix-title:has(.o-footer__matrix-link)`
+	.o-footer__matrix-title--link {
 		// Do not hide overflowing focus state for titles which contain links.
 		overflow: visible;
 		line-height: $_o-footer-spacing-unit * 2;

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -3,186 +3,172 @@
 /// @param {String} $logo-name
 /// @param {Number} $fallback-width
 @mixin _oFooterBrandImage($logo-name, $fallback-width) {
-  // Error if the global $system-code variable is not set.
-  // This is required for image service requests.
-  @if (
-    global-variable-exists("system-code") ==
-      false or
-      type-of($system-code) !=
-      "string"
-  ) {
-    @error 'A global "$system-code" Sass variable must be set to a valid [Bizops system code](https://biz-ops.in.ft.com/list/Systems).';
-  }
+	// Error if the global $system-code variable is not set.
+	// This is required for image service requests.
+	@if(global-variable-exists('system-code') == false or type-of($system-code) != 'string') {
+		@error 'A global "$system-code" Sass variable must be set to a valid [Bizops system code](https://biz-ops.in.ft.com/list/Systems).';
+	}
 
-  $base-url: "https://www.ft.com/__origami/service/image/v2/images/raw/ftlogo:";
-  background-image: url($base-url + $logo-name + "?source=#{$system-code}&format=svg");
+	$base-url: "https://www.ft.com/__origami/service/image/v2/images/raw/ftlogo:";
+	background-image: url($base-url + $logo-name + "?source=#{$system-code}&format=svg");
 }
 
 /// Styles for the dark theme
 /// @param {String} $theme - The theme, see _brand.scss for theme configuration.
 @mixin _oFooterTheme($theme) {
-  @if $theme != "light" and $theme != "dark" {
-    @error 'No theme "#{inspect($theme)}" exists. Supported themes include "light" and "dark".';
-  }
+	@if $theme != 'light' and $theme != 'dark' {
+		@error 'No theme "#{inspect($theme)}" exists. Supported themes include "light" and "dark".';
+	}
 
-  .o-footer--theme-#{$theme} {
-    color: _oFooterGet("text", $from: $theme);
-    background: _oFooterGet("background", $from: $theme);
+	.o-footer--theme-#{$theme} {
+		color: _oFooterGet('text', $from: $theme);
+		background: _oFooterGet('background', $from: $theme);
 
-    .o-footer__title {
-      color: _oFooterGet("title", $from: $theme);
-    }
+		.o-footer__title {
+			color: _oFooterGet('title', $from: $theme);
+		}
 
-    .o-footer__matrix-link--more {
-      display: flex;
+		.o-footer__matrix-link--more {
+			display: flex;
 
-      &:after {
-        @include oIconsContent(
-          $icon-name: "arrow-right",
-          $size: 16,
-          $color: _oFooterGet("text", $from: $theme)
-        );
-        content: "";
-        align-self: center;
-      }
-    }
+			&:after {
+				@include oIconsContent(
+					$icon-name: 'arrow-right',
+					$size: 16,
+					$color: _oFooterGet('text', $from: $theme)
+				);
+				content: '';
+				align-self: center;
+			}
+		}
 
-    .o-footer__matrix-title--external-link,
-    .o-footer__external-link,
-    .o-footer__matrix-title[aria-expanded] {
-      border-color: _oFooterGet("border", $from: $theme);
-    }
+		.o-footer__matrix-title--external-link,
+		.o-footer__external-link,
+		.o-footer__matrix-title[aria-expanded] {
+			border-color: _oFooterGet('border', $from: $theme);
+		}
 
-    .o-footer__matrix-title a {
-      color: _oFooterGet("text", $from: $theme);
-    }
+		.o-footer__matrix-title a {
+			color: _oFooterGet('text', $from: $theme);
+		}
 
-    a {
-      color: _oFooterGet("link", $from: $theme);
+		a {
+			color: _oFooterGet('link', $from: $theme);
 
-      &:hover,
-      &:focus {
-        color: _oFooterGet("link-hover", $from: $theme);
-      }
-    }
+			&:hover,
+			&:focus {
+				color: _oFooterGet('link-hover', $from: $theme);
+			}
+		}
 
-    .o-footer__external-link a:after {
-      @include oIconsContent(
-        "arrow-right",
-        _oFooterGet("title", $from: $theme),
-        $size: $_o-footer-icon-size,
-        $include-base-styles: false
-      );
-    }
+		.o-footer__external-link a:after {
+			@include oIconsContent('arrow-right', _oFooterGet('title', $from: $theme), $size: $_o-footer-icon-size, $include-base-styles: false);
+		}
 
-    .o-footer__copyright {
-      color: _oFooterGet("copyright", $from: $theme);
-    }
+		.o-footer__copyright {
+			color: _oFooterGet('copyright', $from: $theme);
+		}
 
-    .o-footer__brand {
-      color: _oFooterGet("text", $from: $theme);
-      background: _oFooterGet("brand-background", $from: $theme);
-    }
-  }
+		.o-footer__brand {
+			color: _oFooterGet('text', $from: $theme);
+			background: _oFooterGet('brand-background', $from: $theme);
+		}
+	}
 }
 
 /// Styles for the navigation matrix
 /// @param {List} $themes - a list of themes include
 @mixin _oFooterMatrix($themes) {
-  .o-footer__matrix,
-  .o-footer__matrix-content {
-    @include oGridRow();
-  }
+	.o-footer__matrix,
+	.o-footer__matrix-content {
+		@include oGridRow();
+	}
 
-  .o-footer__matrix-group,
-  .o-footer__matrix-column {
-    @include oGridColspan();
-  }
+	.o-footer__matrix-group,
+	.o-footer__matrix-column {
+		@include oGridColspan();
+	}
 
-  @each $key, $value in $_o-footer-matrix {
-    .o-footer__matrix-group--#{$key} {
-      @include oGridColspan(map-get($value, "group"), $width-only: true);
+	@each $key, $value in $_o-footer-matrix {
+		.o-footer__matrix-group--#{$key} {
+			@include oGridColspan(map-get($value, 'group'), $width-only: true);
 
-      .o-footer__matrix-column {
-        @include oGridColspan(map-get($value, "columns"), $width-only: true);
-      }
-    }
-  }
+			.o-footer__matrix-column {
+				@include oGridColspan(map-get($value, 'columns'), $width-only: true);
+			}
+		}
+	}
 
-  .o-footer__matrix-link__copy {
-    overflow: hidden;
-    white-space: nowrap;
-    text-overflow: ellipsis;
-  }
+	.o-footer__matrix-link__copy {
+		overflow: hidden;
+		white-space: nowrap;
+		text-overflow: ellipsis;
+	}
 
-  .o-footer__matrix-title {
-    margin: 0;
-    line-height: inherit;
-    font-size: inherit;
-    font-weight: 600;
+	.o-footer__matrix-title {
+		margin: 0;
+		line-height: inherit;
+		font-size: inherit;
+		font-weight: 600;
 
-    &--external-link {
-      line-height: $_o-footer-spacing-unit * 2;
+		&--external-link {
+			line-height: $_o-footer-spacing-unit * 2;
 
-      border-top: 1px solid;
-      @include oGridRespondTo(M) {
-        border-top: 0;
-        line-height: initial;
-      }
-    }
+			border-top: 1px solid;
+			@include oGridRespondTo(M) {
+				border-top: 0;
+				line-height: initial;
+			}
+		}
 
-    &[aria-expanded] {
-      $line-size: $_o-footer-spacing-unit * 2;
+		&[aria-expanded] {
+			$line-size: $_o-footer-spacing-unit * 2;
 
-      position: relative;
-      border-top: 1px solid;
-      line-height: $line-size;
-      cursor: pointer;
+			position: relative;
+			border-top: 1px solid;
+			line-height: $line-size;
+			cursor: pointer;
 
-      &:after {
-        content: " ";
-        position: absolute;
-        right: 0;
-        top: ($line-size - $_o-footer-icon-size) / 2;
+			&:after {
+				content: ' ';
+				position: absolute;
+				right: 0;
+				top: ($line-size - $_o-footer-icon-size) / 2;
 
-        @each $theme in $themes {
-          .o-footer--theme-#{$theme} & {
-            @include oIconsContent(
-              "arrow-down",
-              _oFooterGet("title", $theme),
-              $size: $_o-footer-icon-size
-            );
-          }
-        }
-      }
-    }
+				@each $theme in $themes {
+					.o-footer--theme-#{$theme} & {
+						@include oIconsContent('arrow-down', _oFooterGet('title', $theme), $size: $_o-footer-icon-size);
+					}
+				}
+			}
+		}
 
-    &[aria-expanded="true"] {
-      &:after {
-        // don't download another icon...
-        transform: rotate(180deg);
-      }
-    }
-  }
+		&[aria-expanded="true"] {
+			&:after {
+				// don't download another icon...
+				transform: rotate(180deg);
+			}
+		}
+	}
 
-  .o-footer__matrix-content {
-    &[aria-hidden="true"] {
-      display: none;
-    }
-  }
+	.o-footer__matrix-content {
+		&[aria-hidden="true"] {
+			display: none;
+		}
+	}
 
-  .o-footer__matrix-column {
-    margin-top: oSpacingByName("s4");
-    margin-bottom: oSpacingByName("s4");
-  }
+	.o-footer__matrix-column {
+		margin-top: oSpacingByName('s4');
+		margin-bottom: oSpacingByName('s4');
+	}
 
-  .o-footer__matrix-link {
-    padding-top: oSpacingByName("s2");
-    padding-bottom: oSpacingByName("s2");
-    display: block;
+	.o-footer__matrix-link {
+		padding-top: oSpacingByName('s2');
+		padding-bottom: oSpacingByName('s2');
+		display: block;
 
-    &:first-child {
-      padding-top: 0;
-    }
-  }
+		&:first-child {
+			padding-top: 0;
+		}
+	}
 }

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -28,18 +28,13 @@
 			color: _oFooterGet('title', $from: $theme);
 		}
 
-		.o-footer__matrix-link--more {
-			display: flex;
-
-			&:after {
-				@include oIconsContent(
-					$icon-name: 'arrow-right',
-					$size: $_o-footer-icon-size,
-					$color: _oFooterGet('text', $from: $theme)
-				);
-				content: '';
-				align-self: center;
-			}
+		.o-footer__matrix-link--more:after {
+			@include oIconsContent(
+				$icon-name: 'arrow-right',
+				$size: $_o-footer-icon-size,
+				$color: _oFooterGet('text', $from: $theme),
+				$include-base-styles: false
+			);
 		}
 
 		.o-footer__matrix-title--link,
@@ -168,6 +163,21 @@
 
 		&:first-child {
 			padding-top: 0;
+		}
+	}
+
+	.o-footer__matrix-link--more {
+		display: flex;
+
+		&:after {
+			@include oIconsContent(
+				$icon-name: 'arrow-right',
+				$size: $_o-footer-icon-size,
+				$color: _oFooterGet('text'),
+				$include-base-styles: true
+			);
+			content: '';
+			align-self: center;
 		}
 	}
 }

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -3,159 +3,186 @@
 /// @param {String} $logo-name
 /// @param {Number} $fallback-width
 @mixin _oFooterBrandImage($logo-name, $fallback-width) {
-	// Error if the global $system-code variable is not set.
-	// This is required for image service requests.
-	@if(global-variable-exists('system-code') == false or type-of($system-code) != 'string') {
-		@error 'A global "$system-code" Sass variable must be set to a valid [Bizops system code](https://biz-ops.in.ft.com/list/Systems).';
-	}
+  // Error if the global $system-code variable is not set.
+  // This is required for image service requests.
+  @if (
+    global-variable-exists("system-code") ==
+      false or
+      type-of($system-code) !=
+      "string"
+  ) {
+    @error 'A global "$system-code" Sass variable must be set to a valid [Bizops system code](https://biz-ops.in.ft.com/list/Systems).';
+  }
 
-	$base-url: "https://www.ft.com/__origami/service/image/v2/images/raw/ftlogo:";
-	background-image: url($base-url + $logo-name + "?source=#{$system-code}&format=svg");
+  $base-url: "https://www.ft.com/__origami/service/image/v2/images/raw/ftlogo:";
+  background-image: url($base-url + $logo-name + "?source=#{$system-code}&format=svg");
 }
 
 /// Styles for the dark theme
 /// @param {String} $theme - The theme, see _brand.scss for theme configuration.
 @mixin _oFooterTheme($theme) {
-	@if $theme != 'light' and $theme != 'dark' {
-		@error 'No theme "#{inspect($theme)}" exists. Supported themes include "light" and "dark".';
-	}
+  @if $theme != "light" and $theme != "dark" {
+    @error 'No theme "#{inspect($theme)}" exists. Supported themes include "light" and "dark".';
+  }
 
-	.o-footer--theme-#{$theme} {
-		color: _oFooterGet('text', $from: $theme);
-		background: _oFooterGet('background', $from: $theme);
+  .o-footer--theme-#{$theme} {
+    color: _oFooterGet("text", $from: $theme);
+    background: _oFooterGet("background", $from: $theme);
 
-		.o-footer__title {
-			color: _oFooterGet('title', $from: $theme);
-		}
+    .o-footer__title {
+      color: _oFooterGet("title", $from: $theme);
+    }
 
-		.o-footer__matrix-title--external-link,
-		.o-footer__external-link,
-		.o-footer__matrix-title[aria-expanded] {
-			border-color: _oFooterGet('border', $from: $theme);
-		}
+    .o-footer__matrix-link--more {
+      display: flex;
 
-		.o-footer__matrix-title a {
-			color: _oFooterGet('text', $from: $theme);
-		}
+      &:after {
+        @include oIconsContent(
+          $icon-name: "arrow-right",
+          $size: 16,
+          $color: _oFooterGet("text", $from: $theme)
+        );
+        content: "";
+        align-self: center;
+      }
+    }
 
-		a {
-			color: _oFooterGet('link', $from: $theme);
+    .o-footer__matrix-title--external-link,
+    .o-footer__external-link,
+    .o-footer__matrix-title[aria-expanded] {
+      border-color: _oFooterGet("border", $from: $theme);
+    }
 
-			&:hover,
-			&:focus {
-				color: _oFooterGet('link-hover', $from: $theme);
-			}
-		}
+    .o-footer__matrix-title a {
+      color: _oFooterGet("text", $from: $theme);
+    }
 
-		.o-footer__external-link a:after {
-			@include oIconsContent('arrow-right', _oFooterGet('title', $from: $theme), $size: $_o-footer-icon-size, $include-base-styles: false);
-		}
+    a {
+      color: _oFooterGet("link", $from: $theme);
 
-		.o-footer__copyright {
-			color: _oFooterGet('copyright', $from: $theme);
-		}
+      &:hover,
+      &:focus {
+        color: _oFooterGet("link-hover", $from: $theme);
+      }
+    }
 
-		.o-footer__brand {
-			color: _oFooterGet('text', $from: $theme);
-			background: _oFooterGet('brand-background', $from: $theme);
-		}
-	}
+    .o-footer__external-link a:after {
+      @include oIconsContent(
+        "arrow-right",
+        _oFooterGet("title", $from: $theme),
+        $size: $_o-footer-icon-size,
+        $include-base-styles: false
+      );
+    }
+
+    .o-footer__copyright {
+      color: _oFooterGet("copyright", $from: $theme);
+    }
+
+    .o-footer__brand {
+      color: _oFooterGet("text", $from: $theme);
+      background: _oFooterGet("brand-background", $from: $theme);
+    }
+  }
 }
 
 /// Styles for the navigation matrix
 /// @param {List} $themes - a list of themes include
 @mixin _oFooterMatrix($themes) {
-	.o-footer__matrix,
-	.o-footer__matrix-content {
-		@include oGridRow();
-	}
+  .o-footer__matrix,
+  .o-footer__matrix-content {
+    @include oGridRow();
+  }
 
-	.o-footer__matrix-group,
-	.o-footer__matrix-column {
-		@include oGridColspan();
-	}
+  .o-footer__matrix-group,
+  .o-footer__matrix-column {
+    @include oGridColspan();
+  }
 
-	@each $key, $value in $_o-footer-matrix {
-		.o-footer__matrix-group--#{$key} {
-			@include oGridColspan(map-get($value, 'group'), $width-only: true);
+  @each $key, $value in $_o-footer-matrix {
+    .o-footer__matrix-group--#{$key} {
+      @include oGridColspan(map-get($value, "group"), $width-only: true);
 
-			.o-footer__matrix-column {
-				@include oGridColspan(map-get($value, 'columns'), $width-only: true);
-			}
-		}
-	}
+      .o-footer__matrix-column {
+        @include oGridColspan(map-get($value, "columns"), $width-only: true);
+      }
+    }
+  }
 
-	.o-footer__matrix-title,
-	.o-footer__matrix-link {
-		overflow: hidden;
-		white-space: nowrap;
-		text-overflow: ellipsis;
-	}
+  .o-footer__matrix-link__copy {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
 
-	.o-footer__matrix-title {
-		margin: 0;
-		line-height: inherit;
-		font-size: inherit;
-		font-weight: 600;
+  .o-footer__matrix-title {
+    margin: 0;
+    line-height: inherit;
+    font-size: inherit;
+    font-weight: 600;
 
-		&--external-link {
-			line-height: $_o-footer-spacing-unit * 2;
-			
-			border-top: 1px solid;
-			@include oGridRespondTo(M) {
-				border-top: 0;
-				line-height: initial;
-			}
-		}
+    &--external-link {
+      line-height: $_o-footer-spacing-unit * 2;
 
-		&[aria-expanded] {
-			$line-size: $_o-footer-spacing-unit * 2;
+      border-top: 1px solid;
+      @include oGridRespondTo(M) {
+        border-top: 0;
+        line-height: initial;
+      }
+    }
 
-			position: relative;
-			border-top: 1px solid;
-			line-height: $line-size;
-			cursor: pointer;
+    &[aria-expanded] {
+      $line-size: $_o-footer-spacing-unit * 2;
 
-			&:after {
-				content: ' ';
-				position: absolute;
-				right: 0;
-				top: ($line-size - $_o-footer-icon-size) / 2;
+      position: relative;
+      border-top: 1px solid;
+      line-height: $line-size;
+      cursor: pointer;
 
-				@each $theme in $themes {
-					.o-footer--theme-#{$theme} & {
-						@include oIconsContent('arrow-down', _oFooterGet('title', $theme), $size: $_o-footer-icon-size);
-					}
-				}
-			}
-		}
+      &:after {
+        content: " ";
+        position: absolute;
+        right: 0;
+        top: ($line-size - $_o-footer-icon-size) / 2;
 
-		&[aria-expanded="true"] {
-			&:after {
-				// don't download another icon...
-				transform: rotate(180deg);
-			}
-		}
-	}
+        @each $theme in $themes {
+          .o-footer--theme-#{$theme} & {
+            @include oIconsContent(
+              "arrow-down",
+              _oFooterGet("title", $theme),
+              $size: $_o-footer-icon-size
+            );
+          }
+        }
+      }
+    }
 
-	.o-footer__matrix-content {
-		&[aria-hidden="true"] {
-			display: none;
-		}
-	}
+    &[aria-expanded="true"] {
+      &:after {
+        // don't download another icon...
+        transform: rotate(180deg);
+      }
+    }
+  }
 
-	.o-footer__matrix-column {
-		margin-top: oSpacingByName('s4');
-		margin-bottom: oSpacingByName('s4');
-	}
+  .o-footer__matrix-content {
+    &[aria-hidden="true"] {
+      display: none;
+    }
+  }
 
-	.o-footer__matrix-link {
-		padding-top: oSpacingByName('s2');
-		padding-bottom: oSpacingByName('s2');
-		display: block;
+  .o-footer__matrix-column {
+    margin-top: oSpacingByName("s4");
+    margin-bottom: oSpacingByName("s4");
+  }
 
-		&:first-child {
-			margin-top: -(oSpacingByName('s2'));
-		}
-	}
+  .o-footer__matrix-link {
+    padding-top: oSpacingByName("s2");
+    padding-bottom: oSpacingByName("s2");
+    display: block;
+
+    &:first-child {
+      padding-top: 0;
+    }
+  }
 }

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -99,10 +99,17 @@
 		}
 	}
 
+	.o-footer__matrix-title,
 	.o-footer__matrix-link__copy {
 		overflow: hidden;
 		white-space: nowrap;
 		text-overflow: ellipsis;
+	}
+
+
+	// Do not hide overflowing focus state for titles which contain links.
+	.o-footer__matrix-title--external-link {
+		overflow: visible;
 	}
 
 	.o-footer__matrix-title {

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -34,7 +34,7 @@
 			&:after {
 				@include oIconsContent(
 					$icon-name: 'arrow-right',
-					$size: 16,
+					$size: $_o-footer-icon-size,
 					$color: _oFooterGet('text', $from: $theme)
 				);
 				content: '';

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -43,7 +43,6 @@
 		}
 
 		.o-footer__matrix-title--external-link,
-		.o-footer__external-link,
 		.o-footer__matrix-title[aria-expanded] {
 			border-color: _oFooterGet('border', $from: $theme);
 		}
@@ -59,10 +58,6 @@
 			&:focus {
 				color: _oFooterGet('link-hover', $from: $theme);
 			}
-		}
-
-		.o-footer__external-link a:after {
-			@include oIconsContent('arrow-right', _oFooterGet('title', $from: $theme), $size: $_o-footer-icon-size, $include-base-styles: false);
 		}
 
 		.o-footer__copyright {

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -28,6 +28,7 @@
 			color: _oFooterGet('title', $from: $theme);
 		}
 
+		.o-footer__matrix-title--external-link,
 		.o-footer__external-link,
 		.o-footer__matrix-title[aria-expanded] {
 			border-color: _oFooterGet('border', $from: $theme);
@@ -96,6 +97,16 @@
 		line-height: inherit;
 		font-size: inherit;
 		font-weight: 600;
+
+		&--external-link {
+			line-height: $_o-footer-spacing-unit * 2;
+			
+			border-top: 1px solid;
+			@include oGridRespondTo(M) {
+				border-top: 0;
+				line-height: initial;
+			}
+		}
 
 		&[aria-expanded] {
 			$line-size: $_o-footer-spacing-unit * 2;

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -101,27 +101,11 @@
 		text-overflow: ellipsis;
 	}
 
-
-	// Do not hide overflowing focus state for titles which contain links.
-	.o-footer__matrix-title--external-link {
-		overflow: visible;
-	}
-
 	.o-footer__matrix-title {
 		margin: 0;
 		line-height: inherit;
 		font-size: inherit;
 		font-weight: 600;
-
-		&--external-link {
-			line-height: $_o-footer-spacing-unit * 2;
-
-			border-top: 1px solid;
-			@include oGridRespondTo(M) {
-				border-top: 0;
-				line-height: initial;
-			}
-		}
 
 		&[aria-expanded] {
 			$line-size: $_o-footer-spacing-unit * 2;
@@ -150,6 +134,18 @@
 				// don't download another icon...
 				transform: rotate(180deg);
 			}
+		}
+	}
+
+	.o-footer__matrix-title--external-link {
+		// Do not hide overflowing focus state for titles which contain links.
+		overflow: visible;
+		line-height: $_o-footer-spacing-unit * 2;
+
+		border-top: 1px solid;
+		@include oGridRespondTo(M) {
+			border-top: 0;
+			line-height: initial;
 		}
 	}
 

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -9,7 +9,7 @@ $_o-footer-spacing-unit: oSpacingByIncrement(5);
 /// @type Map
 $_o-footer-matrix: (
 	1: (
-		group: (default: 6, M: 3, L: 2),
+		group: (default: 12, M: 4, L: 2),
 		columns: (default: 12)
 	),
 	2: (

--- a/test/helpers/fixtures.js
+++ b/test/helpers/fixtures.js
@@ -23,85 +23,132 @@ function insert(html) {
 function htmlCode () {
 	/* Generated from the footer.mustache demo */
 	const html = `<div id="my-footer">
-	<footer class="o-footer o-footer--theme-dark" data-o-component="o-footer" data-o-footer--no-js="">
+<footer class="o-footer o-footer--theme-dark" data-o-component="o-footer" data-o-footer--no-js>
 		<div class="o-footer__container">
+
+			<h2 class="o-footer-visually-hidden">Useful links</h2>
 
 			<div class="o-footer__row">
 				<nav class="o-footer__matrix" role="navigation" aria-label="Useful links">
 					<div class="o-footer__matrix-group o-footer__matrix-group--1">
-						<h3 class="o-footer__matrix-title">
-							Support
+						<h3 class="o-footer__matrix-title" aria-controls="o-footer-section-0">
+							xxxxxxx
 						</h3>
 						<div class="o-footer__matrix-content" id="o-footer-section-0">
 								<div class="o-footer__matrix-column">
-										<a class="o-footer__matrix-link" href="//www.ft.com/help">Help</a>
-										<a class="o-footer__matrix-link" href="//www.ft.com/aboutus">About Us</a>
+										<a class="o-footer__matrix-link"  href="&#x2F;&#x2F;www.ft.com&#x2F;help">
+											<span class="o-footer__matrix-link__copy">xxxx</span>
+										</a>
+										<a class="o-footer__matrix-link"  href="&#x2F;&#x2F;www.ft.com&#x2F;aboutus">
+											<span class="o-footer__matrix-link__copy">xxxxx xx</span>
+										</a>
 								</div>
 						</div>
 					</div>
 					<div class="o-footer__matrix-group o-footer__matrix-group--1">
-						<h3 class="o-footer__matrix-title">
-							Legal &amp; Privacy
+						<h3 class="o-footer__matrix-title" aria-controls="o-footer-section-1">
+							xxxxx x xxxxxxx
 						</h3>
 						<div class="o-footer__matrix-content" id="o-footer-section-1">
 								<div class="o-footer__matrix-column">
-										<a class="o-footer__matrix-link" href="//www.ft.com/servicestools/help/terms">Terms &amp; Conditions</a>
-										<a class="o-footer__matrix-link" href="//www.ft.com/servicestools/help/privacy">Privacy</a>
-										<a class="o-footer__matrix-link" href="//www.ft.com/cookiepolicy">Cookies</a>
-										<a class="o-footer__matrix-link" href="//www.ft.com/servicestools/help/copyright">Copyright</a>
+										<a class="o-footer__matrix-link"  href="&#x2F;&#x2F;www.ft.com&#x2F;servicestools&#x2F;help&#x2F;terms">
+											<span class="o-footer__matrix-link__copy">xxxxx x xxxxxxxxxx</span>
+										</a>
+										<a class="o-footer__matrix-link"  href="&#x2F;&#x2F;www.ft.com&#x2F;servicestools&#x2F;help&#x2F;privacy">
+											<span class="o-footer__matrix-link__copy">xxxxxxx</span>
+										</a>
+										<a class="o-footer__matrix-link"  href="&#x2F;&#x2F;www.ft.com&#x2F;cookiepolicy">
+											<span class="o-footer__matrix-link__copy">xxxxxxx</span>
+										</a>
+										<a class="o-footer__matrix-link"  href="&#x2F;&#x2F;www.ft.com&#x2F;servicestools&#x2F;help&#x2F;copyright">
+											<span class="o-footer__matrix-link__copy">xxxxxxxxx</span>
+										</a>
 								</div>
 						</div>
 					</div>
-					<div class="o-footer__matrix-group o-footer__matrix-group--2">
+					<div class="o-footer__matrix-group o-footer__matrix-group--1">
 						<h3 class="o-footer__matrix-title" aria-controls="o-footer-section-2">
-							Services
+							xxxxxxxx
 						</h3>
 						<div class="o-footer__matrix-content" id="o-footer-section-2">
 								<div class="o-footer__matrix-column">
-										<a class="o-footer__matrix-link" href="//sub.ft.com/spa_5">Individual Subscriptions</a>
-										<a class="o-footer__matrix-link" href="//enterprise.ft.com/en-gb/services/group-subscriptions/">Group Subscriptions</a>
-										<a class="o-footer__matrix-link" href="//enterprise.ft.com/en-gb/services/republishing/">Republishing</a>
-										<a class="o-footer__matrix-link" href="//www.businessesforsale.com/ft2/notices">Contracts &amp; Tenders</a>
-										<a class="o-footer__matrix-link" href="//commerce.uk.reuters.com/purchase/mostPopular.do?rpc&amp;#x3D;471">Analysts Research</a>
-								</div>
-								<div class="o-footer__matrix-column">
-										<a class="o-footer__matrix-link" href="//www.exec-appointments.com/">Executive Job Search</a>
-										<a class="o-footer__matrix-link" aria-label="Advertise with the F T" href="//fttoolkit.co.uk/d/">Advertise with the FT</a>
-										<a class="o-footer__matrix-link" aria-label="Follow the F T on Twitter" href="//twitter.com/ft">Follow the FT on Twitter</a>
+										<a class="o-footer__matrix-link"  href="&#x2F;&#x2F;sub.ft.com&#x2F;spa_5">
+											<span class="o-footer__matrix-link__copy">xxxxxxxxxx xxxxxxxxxxxxx</span>
+										</a>
+										<a class="o-footer__matrix-link"  href="&#x2F;&#x2F;enterprise.ft.com&#x2F;en-gb&#x2F;services&#x2F;group-subscriptions&#x2F;">
+											<span class="o-footer__matrix-link__copy">xxxxx xxxxxxxxxxxxx</span>
+										</a>
+										<a class="o-footer__matrix-link"  href="&#x2F;&#x2F;enterprise.ft.com&#x2F;en-gb&#x2F;services&#x2F;republishing&#x2F;">
+											<span class="o-footer__matrix-link__copy">xxxxxxxxxxxx</span>
+										</a>
+										<a class="o-footer__matrix-link"  href="&#x2F;&#x2F;www.businessesforsale.com&#x2F;ft2&#x2F;notices">
+											<span class="o-footer__matrix-link__copy">xxxxxxxxx x xxxxxxx</span>
+										</a>
+										<a class="o-footer__matrix-link"  href="&#x2F;&#x2F;commerce.uk.reuters.com&#x2F;purchase&#x2F;mostPopular.do?rpc&amp;#x3D;471">
+											<span class="o-footer__matrix-link__copy">xxxxxxxx xxxxxxxx</span>
+										</a>
 								</div>
 						</div>
 					</div>
-					<div class="o-footer__matrix-group o-footer__matrix-group--2">
+					<div class="o-footer__matrix-group o-footer__matrix-group--1">
 						<h3 class="o-footer__matrix-title" aria-controls="o-footer-section-3">
-							Tools
+							xxxxx
 						</h3>
 						<div class="o-footer__matrix-content" id="o-footer-section-3">
 								<div class="o-footer__matrix-column">
-										<a class="o-footer__matrix-link" href="//markets.ft.com/data/portfolio/dashboard">Portfolio</a>
-										<a class="o-footer__matrix-link" href="//ftepaper.ft.com">Today&apos;s Paper</a>
-										<a class="o-footer__matrix-link" href="//markets.ft.com/data/alerts/">Alerts Hub</a>
-										<a class="o-footer__matrix-link" href="//lexicon.ft.com/">Lexicon</a>
-										<a class="o-footer__matrix-link" href="//rankings.ft.com/businessschoolrankings/global-mba-ranking-2016">MBA Rankings</a>
-								</div>
-								<div class="o-footer__matrix-column">
-										<a class="o-footer__matrix-link" href="//markets.ft.com/Research/Economic-Calendar">Economic Calendar</a>
-										<a class="o-footer__matrix-link" href="//nbe.ft.com/nbe/profile.cfm">Newsletters</a>
-										<a class="o-footer__matrix-link" href="//markets.ft.com/research/Markets/Currencies?segid&amp;#x3D;70113">Currency Converter</a>
-										<a class="o-footer__matrix-link" aria-label="E-books" href="//www.ft.com/ebooks">Ebooks</a>
+										<a class="o-footer__matrix-link"  href="&#x2F;&#x2F;markets.ft.com&#x2F;data&#x2F;portfolio&#x2F;dashboard">
+											<span class="o-footer__matrix-link__copy">xxxxxxxxx</span>
+										</a>
+										<a class="o-footer__matrix-link"  href="&#x2F;&#x2F;ftepaper.ft.com">
+											<span class="o-footer__matrix-link__copy">xxxxxxx xxxxx</span>
+										</a>
+										<a class="o-footer__matrix-link"  href="&#x2F;&#x2F;markets.ft.com&#x2F;data&#x2F;alerts&#x2F;">
+											<span class="o-footer__matrix-link__copy">xxxxxx xxx</span>
+										</a>
+										<a class="o-footer__matrix-link"  href="&#x2F;&#x2F;lexicon.ft.com&#x2F;">
+											<span class="o-footer__matrix-link__copy">xxxxxxx</span>
+										</a>
+										<a class="o-footer__matrix-link"  href="&#x2F;&#x2F;rankings.ft.com&#x2F;businessschoolrankings&#x2F;global-mba-ranking-2016">
+											<span class="o-footer__matrix-link__copy">xxx xxxxxxxx</span>
+										</a>
 								</div>
 						</div>
 					</div>
+					<div class="o-footer__matrix-group o-footer__matrix-group--1">
+						<h3 class="o-footer__matrix-title" aria-controls="o-footer-section-4">
+							xxxxxxx
+						</h3>
+						<div class="o-footer__matrix-content" id="o-footer-section-4">
+								<div class="o-footer__matrix-column">
+										<a class="o-footer__matrix-link"  href="&#x2F;&#x2F;markets.ft.com&#x2F;data&#x2F;portfolio&#x2F;dashboard">
+											<span class="o-footer__matrix-link__copy">xxxxxxxxx</span>
+										</a>
+										<a class="o-footer__matrix-link"  href="&#x2F;&#x2F;ftepaper.ft.com">
+											<span class="o-footer__matrix-link__copy">xxxxxxx xxxxx</span>
+										</a>
+										<a class="o-footer__matrix-link"  href="&#x2F;&#x2F;markets.ft.com&#x2F;data&#x2F;alerts&#x2F;">
+											<span class="o-footer__matrix-link__copy">xxxxxx xxx</span>
+										</a>
+										<a class="o-footer__matrix-link"  href="&#x2F;&#x2F;lexicon.ft.com&#x2F;">
+											<span class="o-footer__matrix-link__copy">xxxxxxx</span>
+										</a>
+								</div>
+						</div>
+					</div>
+					<div class="o-footer__matrix-group o-footer__matrix-group--1">
+						<h3 class="o-footer__matrix-title o-footer__matrix-title--link">
+							<a class ='o-footer__matrix-link o-footer__matrix-link--more' id="o-footer-section-5" href="https://ft.com/more-from-ft-group">
+								<span class="o-footer__matrix-link__copy">More from the FT Group</span>
+							</a>
+						</h3>
+					</div>
 				</nav>
-
-				<h3 class="o-footer__external-link o-footer__matrix-title">
-					<a class="o-footer__more-from-ft o-footer__matrix-title" href="http://ft.com/more-from-ft-group">More from the FT Group</a>
-				</h3>
 			</div>
 
 			<div class="o-footer__copyright">
 				<small>
-					Markets data delayed by at least 15 minutes. &#xA9; THE FINANCIAL TIMES LTD 2016.
-					<abbr title="Financial Times" aria-label="F T">FT</abbr> and &#x2020;Financial Times&#x2020; are trademarks of The Financial Times Ltd.<br>
+					Markets data delayed by at least 15 minutes. &#169; THE FINANCIAL TIMES LTD 2020.
+					<abbr title="Financial Times" aria-label="F T">FT</abbr> and ‘Financial Times’ are trademarks of The Financial Times Ltd.<br>
 					The Financial Times and its journalism are subject to a self-regulation regime under the <a href="http://aboutus.ft.com/en-gb/ft-editorial-code/" aria-label="F T Editorial Code of Practice">FT Editorial Code of Practice</a>.
 				</small>
 			</div>

--- a/test/helpers/fixtures.js
+++ b/test/helpers/fixtures.js
@@ -147,7 +147,7 @@ function htmlCode () {
 
 			<div class="o-footer__copyright">
 				<small>
-					Markets data delayed by at least 15 minutes. &#169; THE FINANCIAL TIMES LTD 2020.
+					Markets data delayed by at least 15 minutes. &#169; THE FINANCIAL TIMES LTD 2021.
 					<abbr title="Financial Times" aria-label="F T">FT</abbr> and ‘Financial Times’ are trademarks of The Financial Times Ltd.<br>
 					The Financial Times and its journalism are subject to a self-regulation regime under the <a href="http://aboutus.ft.com/en-gb/ft-editorial-code/" aria-label="F T Editorial Code of Practice">FT Editorial Code of Practice</a>.
 				</small>

--- a/test/oFooter.test.js
+++ b/test/oFooter.test.js
@@ -79,7 +79,7 @@ describe("oFooter", () => {
 				footer.setup();
 
 				proclaim.equal(typeof footer._toggles, 'object');
-				proclaim.equal(footer._toggles.length, 2);
+				proclaim.equal(footer._toggles.length, 5);
 			});
 		});
 		describe("destroy()", () => {


### PR DESCRIPTION
- Add 2 extra columns to o-footer, one for Community Events and More from FT
- Convert More from FT to column
- Allow accordion for small screen

Jira: https://financialtimes.atlassian.net/browse/HIVE-150

<h2>Before</h2>

**Large**
![Screen Shot 2021-06-25 at 5 49 49 PM](https://user-images.githubusercontent.com/9023404/123451210-ce443f80-d5dd-11eb-92b9-e56167d2f01d.png)

**Mid**
![Screen Shot 2021-06-25 at 5 46 19 PM](https://user-images.githubusercontent.com/9023404/123450910-81606900-d5dd-11eb-9448-08088d9313ae.png)

**Small**
![Screen Shot 2021-06-25 at 5 45 50 PM](https://user-images.githubusercontent.com/9023404/123451059-a5bc4580-d5dd-11eb-93bd-00ed1183f714.png)

---

<h2>After</h2>

**Large**
![Screen Shot 2021-06-25 at 5 49 55 PM](https://user-images.githubusercontent.com/9023404/123451177-c5536e00-d5dd-11eb-9f10-24f4d8e2d1d9.png)

**Mid**
![Screen Shot 2021-06-25 at 5 46 10 PM](https://user-images.githubusercontent.com/9023404/123450847-70175c80-d5dd-11eb-80c4-235a4a86d7a7.png)

**Small**
![Screen Shot 2021-06-25 at 5 46 01 PM](https://user-images.githubusercontent.com/9023404/123450975-8cb39480-d5dd-11eb-8820-de251d1fc1d4.png)
