### PR TITLE
Fix text overflow for span inside matrix

### DIFF
--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -89,16 +89,15 @@
 		}
 	}
 
+	.o-footer__matrix-title,
 	.o-footer__matrix-link__copy {
-		overflow: hidden;
-		text-overflow: ellipsis;
-	}
-
-	.o-footer__matrix-title {
 		overflow: hidden;
 		white-space: nowrap;
 		text-overflow: ellipsis;
+		display: block;
+	}
 
+	.o-footer__matrix-title {
 		margin: 0;
 		line-height: inherit;
 		font-size: inherit;


### PR DESCRIPTION
- Issue: text-overflow for the span inside the matrix

- `Before`

![image](https://user-images.githubusercontent.com/9023404/125424226-140c4476-0028-4dba-96f7-b64c9e5e6edf.png)

- `After` 

![Screen Shot 2021-07-13 at 12 18 26 PM](https://user-images.githubusercontent.com/9023404/125435455-b449da71-9ea1-4391-9f7e-89299795e449.png)
